### PR TITLE
feat(skills): add BRD/PRD/TRD creator skills for project documentation

### DIFF
--- a/.claude/skills/brd-creator/SKILL.md
+++ b/.claude/skills/brd-creator/SKILL.md
@@ -1,0 +1,444 @@
+---
+name: brd-creator
+description: Use when users ask to "create a BRD", "write business requirements document", "document business needs", or need help defining business context, goals, users, and high-level requirements before technical design. Also triggers when starting a new project that needs formal documentation, or when stakeholders need alignment on business objectives.
+---
+
+# BRD Creator
+
+Create comprehensive Business Requirements Documents (BRDs) that establish clear business context, stakeholder alignment, and high-level requirements BEFORE diving into product or technical details.
+
+## Core Principle
+
+**BRD answers "WHY" and "WHO" — not "HOW" or "WHAT".**
+
+- **WHY**: Business context, problems, goals, success criteria
+- **WHO**: Stakeholders, users, roles, responsibilities
+- **NOT**: Technical architecture, API design, database schema, implementation details
+
+## When to Use This Skill
+
+```dot
+digraph when_brd {
+    "Starting new project?" [shape=diamond];
+    "Have business context?" [shape=diamond];
+    "Need stakeholder alignment?" [shape=diamond];
+
+    "Starting new project?" -> "Have business context?" [label="yes"];
+    "Have business context?" -> "Need stakeholder alignment?" [label="no, need to gather"];
+    "Have business context?" -> "Create BRD" [label="yes"];
+    "Need stakeholder alignment?" -> "Create BRD" [label="yes"];
+    "Need stakeholder alignment?" -> "Skip BRD" [label="no, already aligned"];
+    "Starting new project?" -> "Skip BRD" [label="no, just a task"];
+}
+```
+
+**Use BRD when:**
+- New project or major initiative
+- Multiple stakeholders need alignment
+- Business context is unclear or undocumented
+- Need to justify investment or resources
+- Requirements are fuzzy and need clarification
+
+**Skip BRD when:**
+- Small feature or bug fix
+- Clear, well-understood requirements
+- Single stakeholder with clear vision
+- Just documenting existing decisions
+
+## Discovery Workflow
+
+### Phase 1: Understand Business Context
+
+Before writing anything, gather this information through conversation:
+
+**Required Information:**
+1. **Business Problem** — What problem are we solving? Why now?
+2. **Business Goals** — What outcomes do we want? How do we measure success?
+3. **Target Users** — Who will use this? What are their roles?
+4. **Constraints** — Timeline, budget, resources, compliance requirements
+5. **Scope** — What's in? What's explicitly out?
+6. **Stakeholders** — Who cares about this? Who decides?
+
+**Discovery Questions:**
+```
+1. What business problem triggered this project?
+2. Who is affected by this problem? How badly?
+3. What does success look like in 6 months? 1 year?
+4. Who are the primary users? Secondary users?
+5. What constraints do we have (time, budget, compliance)?
+6. What's explicitly out of scope for now?
+7. Who needs to approve this? Who else cares?
+8. Are there existing systems/processes this replaces or integrates with?
+```
+
+**Pro tip:** If the user can't answer these questions, the BRD process helps surface them. Don't proceed to writing until you have enough context.
+
+### Phase 2: Generate BRD Structure
+
+Use this standard BRD template:
+
+```markdown
+# BRD: [Project Name] Business Requirements Document
+
+> Version: v0.1-draft
+> Date: YYYY-MM-DD
+> Status: draft/review/approved
+
+---
+
+## 1. Project Background & Goals
+
+### 1.1 Background
+[Why this project exists. What problem we're solving. Current state.]
+
+### 1.2 Business Goals
+[What outcomes we want. Measurable objectives.]
+
+### 1.3 Design Principles (optional)
+[Guiding principles for decision-making.]
+
+### 1.4 Implementation Strategy (optional)
+[Phased approach if applicable.]
+
+---
+
+## 2. Users & Roles
+
+| Role | Description | MVP? |
+|------|-------------|------|
+| [Role name] | [Who they are, what they do] | Yes/No |
+
+---
+
+## 3. Core Functional Requirements
+
+### 3.1 [Category 1]
+[Description of functional area]
+
+| Configuration | Description |
+|---------------|-------------|
+| [Item] | [What it is] |
+
+### 3.2 [Category 2]
+...
+
+---
+
+## 4. Non-Functional Requirements
+
+### 4.1 Deployment Architecture
+[High-level deployment context]
+
+### 4.2 Technical Stack (optional)
+[Only if business-relevant — otherwise defer to TRD]
+
+### 4.3 Multi-tenancy (if applicable)
+### 4.4 Scalability
+### 4.5 Observability
+
+---
+
+## 5. Glossary
+
+| Term | Definition |
+|------|------------|
+| [Term] | [What it means in this context] |
+
+---
+
+## 6. Appendix
+
+### 6.1 Open Questions
+- [ ] [Question 1]
+- [ ] [Question 2]
+
+### 6.2 References
+- [Relevant documents, links]
+
+---
+
+## Revision History
+
+| Version | Date | Changes | Author |
+|---------|------|---------|--------|
+| v0.1-draft | YYYY-MM-DD | Initial draft | - |
+```
+
+## Critical Rules (Avoid These Mistakes)
+
+### Rule 1: No Technical Implementation Details
+
+**BRD is NOT the place for:**
+- Database schema design
+- API specifications
+- Class diagrams
+- Code examples
+- Specific technology choices (unless business-mandated)
+
+```
+❌ BAD: "Use PostgreSQL with read replicas for high availability"
+✅ GOOD: "System must support 10,000 concurrent users with <100ms response time"
+
+❌ BAD: "Implement REST API with JWT authentication"
+✅ GOOD: "Users must be authenticated before accessing sensitive data"
+```
+
+### Rule 2: Maintain Document Hierarchy
+
+```
+BRD (Business Requirements Document)
+├── WHY — Business context, goals, success criteria
+├── WHO — Users, roles, stakeholders
+└── WHAT — High-level functional requirements (NOT implementation)
+
+PRD (Product Requirements Document)
+├── User stories and acceptance criteria
+├── Feature specifications
+├── UX flows and wireframes
+└── Success metrics
+
+TRD (Technical Requirements Document)
+├── Architecture design
+├── API specifications
+├── Database schema
+├── Technology stack decisions
+└── Implementation details
+```
+
+**If you're writing technical details in BRD → STOP → Move to TRD**
+
+### Rule 3: Be Specific and Measurable
+
+```
+❌ BAD: "The system should be fast"
+✅ GOOD: "Page load time < 2 seconds for 95th percentile"
+
+❌ BAD: "Support many users"
+✅ GOOD: "Support 10,000 concurrent users during peak hours"
+
+❌ BAD: "Easy to use"
+✅ GOOD: "New users can complete core task within 5 minutes without training"
+```
+
+### Rule 4: Keep It Living
+
+- Mark status clearly (draft/review/approved)
+- Track revision history
+- List open questions explicitly
+- Update when requirements change
+
+## Phase 3: Logic & Completeness Review (Critical)
+
+After drafting the BRD, perform these checks BEFORE finalizing:
+
+### 3.1 Logic Consistency Check
+
+**Goal-Requirement Alignment:**
+```
+For each business goal in section 1.2:
+  → Is there at least one requirement that directly supports it?
+  → Can we trace from requirement back to goal?
+  → Are there orphan requirements (no goal connection)?
+```
+
+**Role-Function Alignment:**
+```
+For each role in section 2:
+  → Are their needs represented in functional requirements?
+  → Are there functions that no role cares about? (red flag)
+  → Are there roles with no functions? (red flag)
+```
+
+**Scope Consistency:**
+```
+For each requirement:
+  → Is it clearly within scope boundaries?
+  → Are there hidden scope expansions in requirements?
+  → Do constraints in 1.1 align with what's being asked?
+```
+
+### 3.2 Completeness Check
+
+**Stakeholder Coverage:**
+- [ ] Every stakeholder mentioned has their concerns addressed
+- [ ] No stakeholder group is implicitly assumed but not listed
+- [ ] Approval chain is clear (who needs to sign off)
+
+**Constraint Coverage:**
+- [ ] Time constraints mentioned and realistic
+- [ ] Budget/resource constraints considered
+- [ ] Compliance/regulatory constraints identified
+- [ ] Technical constraints (if any) stated at business level
+
+**Assumption Surfacing:**
+- [ ] What are we assuming about user behavior?
+- [ ] What are we assuming about existing systems?
+- [ ] What are we assuming about resources?
+- [ ] List all assumptions explicitly in Appendix
+
+### 3.3 Clarity & Ambiguity Check
+
+**Trigger Questions:**
+1. Are there any terms that could mean different things to different readers?
+2. Are there requirements that could be interpreted multiple ways?
+3. Are there "obvious" things that weren't written down? (Write them down)
+4. Are there dependencies between requirements that aren't stated?
+
+**Ambiguity Resolution Process:**
+```
+For each ambiguous statement found:
+  1. Flag it explicitly
+  2. List possible interpretations
+  3. Ask user to clarify
+  4. Replace with specific, measurable statement
+```
+
+## Self-Review Checklist
+
+Before finalizing the BRD, verify:
+
+### Completeness
+- [ ] **Problem is clear**: Anyone can understand why this project exists
+- [ ] **Goals are measurable**: Success can be objectively determined
+- [ ] **Users are identified**: We know who we're building for
+- [ ] **Scope is bounded**: Clear what's in and out
+- [ ] **Stakeholders are named**: We know who needs to approve
+
+### Logic Consistency
+- [ ] **Goal-requirement traceability**: Each requirement links to a goal
+- [ ] **Role-function coverage**: Each role's needs are addressed
+- [ ] **No orphan content**: Everything has a clear purpose
+- [ ] **Assumptions explicit**: Hidden assumptions are surfaced
+
+### Quality
+- [ ] **No technical details**: Implementation is NOT specified (that's TRD)
+- [ ] **Open questions listed**: Unresolved items are tracked
+- [ ] **Consistent terminology**: Same terms mean same things throughout
+- [ ] **Ambiguities resolved**: No statements with multiple interpretations
+
+## Common Anti-Patterns
+
+| Anti-Pattern | Why It's Bad | Fix |
+|--------------|--------------|-----|
+| **Kitchen Sink** | Everything including technical details | Focus on business needs only |
+| **Vague Goals** | "Improve user experience" | Make measurable: "Reduce task completion time by 30%" |
+| **Hidden Assumptions** | Unstated constraints cause rework | List assumptions explicitly |
+| **Missing Stakeholders** | Surprised by late objections | Identify all stakeholders early |
+| **Scope Creep** | "Also need X, Y, Z..." | Define MVP clearly, defer to backlog |
+
+## Example Usage
+
+**User:** "Help me create a BRD for a customer portal"
+
+**Assistant will:**
+1. Ask discovery questions about business problem, goals, users
+2. Identify constraints and scope
+3. Generate BRD using template
+4. Review for technical leakage (move any to TRD)
+5. List open questions for stakeholder review
+6. Track revision as needs evolve
+
+## Relationship to Other Documents
+
+```
+                    ┌─────────────────────────────────────┐
+                    │           Business Need             │
+                    └─────────────────┬───────────────────┘
+                                      │
+                                      ▼
+                    ┌─────────────────────────────────────┐
+                    │         BRD (This Document)          │
+                    │   WHY + WHO + High-level WHAT        │
+                    └─────────────────┬───────────────────┘
+                                      │
+                    ┌─────────────────┴───────────────────┐
+                    ▼                                     ▼
+    ┌───────────────────────────┐     ┌───────────────────────────┐
+    │           PRD              │     │           TRD              │
+    │   Features + User Stories  │     │   Architecture + Tech      │
+    │   UX Flows + Metrics       │     │   APIs + Database          │
+    └───────────────────────────┘     └───────────────────────────┘
+```
+
+**Key insight:** BRD comes FIRST. PRD and TRD derive from BRD. If BRD is wrong, everything downstream is wrong.
+
+---
+
+## Phase 4: Iteration & Refinement (Critical)
+
+BRD is a living document. After initial drafting, expect multiple rounds of iteration:
+
+### 4.1 Iteration Triggers
+
+**When to iterate:**
+- Stakeholder feedback received
+- New information discovered
+- Scope changes requested
+- Inconsistencies found during review
+- Assumptions proved wrong
+
+### 4.2 Iteration Workflow
+
+```
+For each feedback item:
+  1. Classify: Is it a clarification, addition, change, or deletion?
+  2. Impact: Which sections does this affect?
+  3. Consistency: Does this change create inconsistencies elsewhere?
+  4. Update: Make the change
+  5. Trace: Update revision history
+  6. Re-check: Run Phase 3 checks again
+```
+
+### 4.3 Version Control
+
+**Revision History Best Practices:**
+- Increment version for each significant change
+- Record what changed and why
+- Note who requested/approved the change
+- Keep previous versions accessible for reference
+
+```
+| Version | Date | Changes | Author | Status |
+|---------|------|---------|--------|--------|
+| v0.1-draft | 2026-03-22 | Initial draft | AI | draft |
+| v0.2-draft | 2026-03-22 | Added stakeholder feedback; clarified scope | AI | draft |
+| v0.5-review | 2026-03-23 | Incorporated tech team input; ready for review | AI | review |
+| v1.0-approved | 2026-03-24 | Approved by all stakeholders | PM | approved |
+```
+
+### 4.4 Common Iteration Scenarios
+
+| Scenario | Action |
+|----------|--------|
+| **Stakeholder adds requirement** | Check scope impact → Update if within scope → Defer to backlog if out of scope |
+| **Technical team flags infeasibility** | Clarify business need → Explore alternatives → Update requirement |
+| **User feedback changes priorities** | Re-evaluate MVP scope → Update phased approach if needed |
+| **External constraint discovered** | Document constraint → Assess impact → Update affected sections |
+| **Terminology confusion** | Add to glossary → Ensure consistent usage throughout |
+
+### 4.5 Sign-off Process
+
+**Before marking BRD as "approved":**
+- [ ] All stakeholders have reviewed
+- [ ] All open questions resolved
+- [ ] All Phase 3 checks pass
+- [ ] Revision history complete
+- [ ] Next steps (PRD/TRD) identified
+
+---
+
+## References & Inspiration
+
+This skill synthesizes best practices from multiple sources:
+
+| Source | Key Insights Borrowed |
+|--------|----------------------|
+| **jamesrochabrun/prd-generator** (GitHub) | Discovery phase structure, SMART requirements, self-review checklist |
+| **johnnychauvet/prd-skill** (GitHub) | JTBD (Jobs To Be Done) thinking, conversational discovery flow |
+| **alirezarezvani/claude-skills** (GitHub) | Skill structure patterns, progressive disclosure |
+| **Real-world collaboration experience** | Document hierarchy (BRD→PRD→TRD), iteration importance, common mistakes |
+
+**Why these sources:**
+- They represent high-star, production-tested patterns from the Claude Code community
+- They balance structure with flexibility
+- They emphasize discovery before documentation

--- a/.claude/skills/prd-creator/SKILL.md
+++ b/.claude/skills/prd-creator/SKILL.md
@@ -1,0 +1,256 @@
+---
+name: prd-creator
+description: Use when users ask to "create a PRD", "write product requirements document", "document user stories", "define features", "write acceptance criteria", or need help with user-facing specifications AFTER having a BRD. Also triggers when converting business requirements into product specs, mapping user journeys, defining UX flows, setting success metrics, or when stakeholders need alignment on what users will experience. Make sure to use this skill whenever the user mentions "user stories", "personas", "acceptance criteria", "success metrics", "HEART framework", or wants to translate business needs into concrete features, even if they don't explicitly ask for a "PRD". Always check if a BRD exists first — if not, recommend creating one.
+---
+
+# PRD Creator
+
+Create comprehensive Product Requirements Documents (PRDs) that define user stories, feature specifications, UX flows, and success metrics — building on BRD's business context to answer WHAT users need.
+
+## Core Principle
+
+**PRD answers "WHAT" for users — not "HOW" to implement.**
+
+- **WHAT**: User stories, feature specifications, UX flows, success metrics
+- **NOT**: API design, database schema, code architecture, technology stack
+
+```
+BRD → PRD → TRD
+WHY/WHO → WHAT (user-facing) → HOW (technical)
+```
+
+**Key insight:** PRD bridges BRD's business context to TRD's technical implementation. If you're writing technical details → STOP → That belongs in TRD.
+
+## When to Use This Skill
+
+**Use PRD when:**
+- BRD exists and business context is clear
+- Need to translate business needs into user-facing features
+- Defining user stories and acceptance criteria
+- Mapping user journeys and UX flows
+- Setting measurable success metrics
+
+**Skip PRD when:**
+- No BRD exists (create BRD first using brd-creator skill)
+- Just a small feature or bug fix
+- Clear, well-understood product requirements
+
+## Phase 1: Input Validation (BRD Check)
+
+**CRITICAL: PRD requires BRD as input.**
+
+Before proceeding, ask: "Do you have an existing BRD for this project?"
+
+- **If YES** → Extract key information from BRD
+- **If NO** → Recommend creating BRD first using brd-creator skill
+
+### Extract from BRD
+
+| BRD Section | PRD Input | Purpose |
+|-------------|-----------|---------|
+| Business Goals | Goals → Success Metrics | Ensure metrics measure business outcomes |
+| Users & Roles | Personas | Build user stories for each persona |
+| Functional Requirements | Feature specs | Translate to user-facing features |
+| Constraints | Scope boundaries | Define in-scope vs out-of-scope |
+| Stakeholders | Open Questions owners | Identify who to consult |
+
+### BRD-PRD Traceability
+
+Every PRD element should trace back to BRD. If you can't trace a story to a BRD requirement → ask: Is this truly needed for MVP?
+
+## Phase 2: Discovery & Design Clarification
+
+### JTBD Questions (Jobs To Be Done)
+*See `references/jtbd-guide.md` for detailed framework explanation.*
+
+1. **Situation**: When does this need arise for users? What triggers it?
+2. **Motivation**: Why would users "hire" this product? What are they trying to achieve?
+3. **Outcome**: What does success look like from the user's perspective?
+4. **Current alternatives**: How do users solve this problem today? What frustrates them about current solutions?
+5. **Emotional context**: How do users feel when facing this problem? (stressed, confused, frustrated?)
+
+### User Journey Questions
+1. What does a typical user session look like?
+2. What's the first thing users see/do?
+3. What are the most common tasks? (80/20 rule)
+4. Where do users get confused or frustrated today?
+5. What would make users say "wow, this is great"?
+
+### Feature Prioritization Questions
+1. If we could only ship ONE feature, what would it be?
+2. What features are "nice to have" vs "must have"?
+3. What features differentiate us from alternatives?
+
+### UX Design Questions
+1. What's the primary entry point for users?
+2. How many steps should the core task take? (Fewer = better)
+3. What feedback do users need during tasks?
+4. How should errors be communicated?
+
+### Design Trade-off Questions
+1. Power vs Simplicity: Expert features or beginner-friendly?
+2. Flexibility vs Consistency: Customizable or standardized?
+3. Speed vs Accuracy: Fast with occasional errors or slow but correct?
+
+## Phase 3: Generate PRD
+
+**Read the template from `references/prd-template.md` to generate the PRD document.**
+
+The template includes all sections: Executive Summary, Problem & Opportunity, User Personas & Scenarios, User Stories (Gherkin format), UX & Design Requirements, Success Metrics (HEART framework), Scope, Risks & Mitigation, Dependencies & Assumptions, Open Questions, and Revision History.
+
+**Fill in the template with information gathered from:**
+- BRD (business goals, users, requirements)
+- Discovery questions (user journeys, priorities, trade-offs)
+- User scenario mapping
+
+## Phase 4: Logic & Completeness Review
+
+After drafting the PRD, perform these checks BEFORE finalizing:
+
+### 4.1 BRD-PRD Traceability
+- Each user story traces to a BRD requirement?
+- Each persona has relevant user stories?
+- No orphan stories (no BRD connection)?
+
+### 4.2 Metric-Goal Alignment
+- Each business goal has at least one HEART metric?
+- Each HEART metric supports a business goal?
+
+### 4.3 No Technical Leakage
+**RED FLAG TERMS (should NOT appear in PRD):**
+- API, REST, GraphQL, endpoint, database, schema, SQL
+- Microservice, Kubernetes, JWT, OAuth, React, Vue, Redis
+
+If found → Replace with user-facing language (e.g., "Users must be authenticated" instead of "Use JWT")
+
+### 4.4 Completeness Checklist
+- [ ] Executive Summary: Clear 3-sentence overview
+- [ ] Personas: Each has name, role, pain points
+- [ ] User Stories: Gherkin format with acceptance criteria
+- [ ] UX Flows: Entry points and paths shown
+- [ ] Success Metrics: HEART framework with targets
+- [ ] Scope: Clear in/out boundaries
+- [ ] Open Questions: Owners and due dates assigned
+
+## Phase 5: Iteration & Refinement
+
+PRD is a living document. Iterate based on:
+- User feedback from testing/research
+- Stakeholder review comments
+- Scope changes requested
+- BRD updates (PRD must stay aligned)
+
+### Sign-off Process
+Before marking PRD as "approved":
+- [ ] All stakeholders have reviewed
+- [ ] All open questions resolved
+- [ ] All Phase 4 checks pass
+- [ ] Ready for TRD creation
+
+## Critical Rules
+
+### Rule 1: No Technical Implementation
+```
+❌ BAD: "Use REST API with JWT authentication"
+✅ GOOD: "Users must be securely authenticated"
+
+❌ BAD: "Store data in PostgreSQL with indexing"
+✅ GOOD: "User data must be persisted and retrievable"
+
+❌ BAD: "Implement using React with Redux"
+✅ GOOD: "UI must respond to user input within 100ms"
+```
+
+### Rule 2: User-First Language
+```
+❌ BAD: "The system will..."
+✅ GOOD: "Users can..."
+
+❌ BAD: "Backend will process..."
+✅ GOOD: "When users submit..."
+
+❌ BAD: "API returns..."
+✅ GOOD: "Users will see..."
+```
+
+### Rule 3: Every Feature Needs User Value
+For each feature, ask: WHO uses this? WHAT do they do? WHY do they care?
+
+If you can't answer all three → The feature may not be needed.
+
+## Self-Review Checklist
+
+Before finalizing, verify:
+
+### BRD Alignment
+- [ ] BRD exists: PRD is built on documented business requirements
+- [ ] Traceability: Each story traces to BRD requirement
+- [ ] Goal alignment: Metrics measure BRD goals
+
+### User Focus
+- [ ] Personas defined: Clear who we're building for
+- [ ] User Stories complete: Gherkin format with acceptance criteria
+- [ ] User value clear: Every feature has "So that..." clause
+
+### Quality
+- [ ] No technical leakage: Implementation details moved to TRD
+- [ ] User-first language: No system-centric phrasing
+- [ ] Measurable metrics: HEART framework with targets
+
+## Common Anti-Patterns
+
+| Anti-Pattern | Why It's Bad | Fix |
+|--------------|--------------|-----|
+| **Technical Leakage** | PRD contains API/DB details | Replace with user-facing language |
+| **Missing User Value** | Features without "So that..." | Add user benefit or remove feature |
+| **Vague Stories** | "As a user I want a button" | Specify: what button, why, what happens |
+| **No BRD Reference** | Orphan requirements | Trace back to BRD or remove |
+| **Unmeasurable Metrics** | "Improve user experience" | Use HEART: "Task completion rate ≥95%" |
+| **Missing Error Paths** | Only happy path documented | Add error scenarios and recovery |
+
+## Example: User Story Format
+
+```gherkin
+As a developer,
+I want to create a new task from a template,
+So that I don't have to configure the same settings every time.
+
+Acceptance Criteria:
+✓ GIVEN I'm on the task creation page WHEN I select a template THEN the form is pre-filled with template values
+✓ GIVEN I've modified template values WHEN I submit THEN the task is created with my custom values
+✓ GIVEN the template is invalid WHEN I submit THEN I see a clear error message explaining what's wrong
+```
+
+## Relationship to Other Documents
+
+```
+BRD (Business Requirements)
+├── WHY — Business context, goals
+├── WHO — Users, roles
+└── High-level requirements
+
+        ↓ PRD builds on BRD ↓
+
+PRD (This Document)
+├── User Stories — Who needs what and why
+├── Feature Specs — User-facing functionality
+├── UX Flows — How users interact
+├── Success Metrics — Measurable outcomes
+└── Design Decisions — UI/UX choices
+
+        ↓ TRD builds on PRD ↓
+
+TRD (Technical Requirements)
+├── Architecture design
+├── API specifications
+├── Database schema
+└── Technology stack
+```
+
+---
+
+## References
+
+- `references/prd-template.md` — Full PRD template with all sections
+- `references/jtbd-guide.md` — Jobs To Be Done framework guide for understanding user motivations
+- **brd-creator skill** — For creating the prerequisite BRD

--- a/.claude/skills/prd-creator/references/jtbd-guide.md
+++ b/.claude/skills/prd-creator/references/jtbd-guide.md
@@ -1,0 +1,280 @@
+# Jobs To Be Done (JTBD) Framework Guide
+
+> A user-centered approach to understanding why users "hire" products to accomplish their goals.
+
+---
+
+## What is JTBD?
+
+JTBD (Jobs To Be Done) is a framework that shifts focus from **user demographics** to **user motivations**. Instead of asking "Who is the user?", JTBD asks "What job is the user trying to get done?"
+
+### Core Insight
+
+> "People don't buy products; they hire them to do a job." — Clayton Christensen
+
+Users have **jobs** (tasks, problems, goals) they need to accomplish. Your product is a **candidate** they might hire to do those jobs.
+
+---
+
+## JTBD vs Traditional Personas
+
+| Traditional Persona | JTBD Approach |
+|--------------------|---------------|
+| "Alex is a 28-year-old developer" | "Alex needs to quickly spin up dev environments" |
+| Demographics-focused | Motivation-focused |
+| Who they are | What they're trying to achieve |
+| Static attributes | Situational context |
+
+**Key shift:** From "Who is this person?" to "Why would they use this product in this moment?"
+
+---
+
+## Jobs Statement Format
+
+A well-formed Jobs Statement follows this structure:
+
+```
+When [situation],
+I want to [motivation],
+So that I can [expected outcome].
+```
+
+### Example
+
+```
+When I'm starting a new project and need consistent configuration,
+I want to create tasks from pre-defined templates,
+So that I can save time and avoid configuration errors.
+```
+
+### Components
+
+| Component | Question | Example |
+|-----------|----------|---------|
+| **Situation** | When does this job arise? | "When I'm under deadline pressure..." |
+| **Motivation** | What drives the user? | "I want to quickly reproduce a bug..." |
+| **Outcome** | What does success look like? | "So I can fix it before the release" |
+
+---
+
+## JTBD Interview Questions
+
+Use these during discovery to uncover true motivations:
+
+### Situation Questions
+- "When did you last [perform related task]?"
+- "What was happening that made you decide to [take action]?"
+- "Walk me through the last time you encountered [problem]."
+
+### Motivation Questions
+- "What were you trying to accomplish?"
+- "Why was that important to you?"
+- "What would have happened if you couldn't do that?"
+
+### Outcome Questions
+- "How did you know you were successful?"
+- "What did success look like?"
+- "How would you explain the value to a colleague?"
+
+### Struggle Questions (most revealing)
+- "What was the hardest part?"
+- "What frustrated you most?"
+- "What workarounds did you try?"
+
+---
+
+## Integrating JTBD with User Stories
+
+### Standard User Story
+```gherkin
+As a developer,
+I want to create tasks from templates,
+So that I save time.
+```
+
+### JTBD-Enhanced User Story
+```gherkin
+As a developer under deadline pressure,
+When I need to quickly spin up a new task,
+I want to create tasks from templates,
+So that I can avoid configuration errors and meet my deadline.
+
+Acceptance Criteria:
+✓ GIVEN I'm on the task creation page with time pressure
+  WHEN I select a template
+  THEN the form is pre-filled and I can submit in under 30 seconds
+✓ GIVEN I select a template
+  WHEN I review the pre-filled values
+  THEN I see clear validation of any configuration issues
+```
+
+### Enhancement Checklist
+
+| Element | Standard Story | JTBD-Enhanced |
+|---------|---------------|---------------|
+| **Context** | Implicit | Explicit situation |
+| **Urgency** | Missing | Clear time/pressure indicator |
+| **Emotional state** | Missing | Frustration, anxiety, or relief |
+| **Outcome measure** | Vague | Specific success criteria |
+
+---
+
+## JTBD Types
+
+### 1. Functional Jobs
+Getting a practical task done.
+
+```
+When I need to deploy code to production,
+I want a one-click deployment button,
+So I can ship features faster.
+```
+
+### 2. Emotional Jobs
+Achieving a feeling or emotional state.
+
+```
+When I'm presenting to executives,
+I want confidence that my data is accurate,
+So I feel prepared and professional.
+```
+
+### 3. Social Jobs
+How users want to be perceived by others.
+
+```
+When I share my work with the team,
+I want it to look polished and professional,
+So my colleagues respect my attention to detail.
+```
+
+---
+
+## Job Map Template
+
+Use this to map the full job lifecycle:
+
+| Phase | Questions to Ask | Example |
+|-------|------------------|---------|
+| **Define** | How do users decide they need to do this? | "I notice my code isn't working as expected" |
+| **Locate** | Where do they look for solutions? | "I search internal docs or Stack Overflow" |
+| **Select** | How do they choose a solution? | "I compare options based on speed and reliability" |
+| **Prepare** | What setup is needed? | "I need to configure my environment first" |
+| **Execute** | What's the core action? | "I run the debugging tool" |
+| **Monitor** | How do they track progress? | "I watch the console output" |
+| **Modify** | What adjustments might be needed? | "I tweak parameters if it doesn't work" |
+| **Conclude** | How do they know it's done? | "I see the bug fixed and tests passing" |
+
+---
+
+## Competitors in JTBD
+
+Your competitors aren't just similar products—they're **any alternative** users hire to do the job.
+
+### For "Debug code quickly" job:
+
+| Competitor Type | Example |
+|-----------------|---------|
+| **Direct** | Other debugging tools |
+| **Indirect** | Stack Overflow, documentation |
+| **Non-consumption** | Ignoring the bug, restarting |
+| **Workaround** | Console.log debugging |
+
+**Key insight:** If users are "hiring" console.log, your fancy debugger is competing against a free, familiar alternative.
+
+---
+
+## JTBD Discovery Checklist
+
+Before finalizing PRD, ensure you can answer:
+
+- [ ] **What job** is the user trying to get done?
+- [ ] **When** does this job arise? (situation)
+- [ ] **Why** is this job important to the user? (motivation)
+- [ ] **What outcome** defines success? (expected result)
+- [ ] **What alternatives** are they currently hiring?
+- [ ] **What struggles** do they face with current solutions?
+- [ ] **What would make** them switch to your solution?
+
+---
+
+## Quick Reference: JTBD One-Pager
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    JOBS TO BE DONE                          │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│   WHEN [situation/trigger]                                  │
+│   │                                                         │
+│   │   "When I'm [doing something] and [problem occurs]..."  │
+│   │                                                         │
+│   ▼                                                         │
+│   I WANT TO [motivation/action]                             │
+│   │                                                         │
+│   │   "I want to [do something about it]..."                │
+│   │                                                         │
+│   ▼                                                         │
+│   SO THAT I CAN [expected outcome]                          │
+│                                                             │
+│       "So I can [achieve desired result]"                   │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Example: Developer Platform
+
+### Job Statement
+```
+When I'm on-call and receive an alert at 2am,
+I want to quickly identify the root cause,
+So I can fix the issue and go back to sleep.
+```
+
+### Derived User Stories
+
+**Story 1: Quick Access**
+```gherkin
+As an on-call developer,
+When I receive an alert at 2am,
+I want one-click access to relevant logs,
+So I can start investigating within 30 seconds.
+```
+
+**Story 2: Context Preservation**
+```gherkin
+As an on-call developer,
+When I'm debugging an incident,
+I want to see related recent changes,
+So I can quickly identify potential causes.
+```
+
+**Story 3: Guided Resolution**
+```gherkin
+As an on-call developer,
+When I identify the issue,
+I want suggested remediation steps,
+So I can resolve it even when half-asleep.
+```
+
+---
+
+## When to Use JTBD
+
+| Use JTBD When | Skip JTBD When |
+|---------------|----------------|
+| Exploring new product ideas | Simple feature additions |
+| User research phase | Well-understood requirements |
+| Competitive analysis | Maintenance work |
+| Defining MVP scope | Bug fixes |
+| Writing positioning/messaging | Technical debt |
+
+---
+
+## References
+
+- "Competing Against Luck" by Clayton Christensen
+- "When Coffee and Kale Compete" by Alan Klement
+- JTBD.org framework documentation

--- a/.claude/skills/prd-creator/references/prd-template.md
+++ b/.claude/skills/prd-creator/references/prd-template.md
@@ -1,0 +1,284 @@
+# PRD Template Reference
+
+> **When to use:** Read this file when you're ready to generate the PRD document after completing discovery.
+
+---
+
+# 📄 PRD: [Product/Feature Name]
+
+> **Version:** v0.1-draft | **Date:** YYYY-MM-DD | **Status:** 🟡 Draft
+> **BRD Reference:** [Link to BRD document]
+
+---
+
+## 📋 Table of Contents
+
+1. [Executive Summary](#executive-summary)
+2. [Problem & Opportunity](#problem--opportunity)
+3. [User Personas & Scenarios](#user-personas--scenarios)
+4. [User Stories](#user-stories)
+5. [UX & Design Requirements](#ux--design-requirements)
+6. [Success Metrics (HEART)](#-success-metrics-heart)
+7. [Scope](#-scope)
+8. [Risks & Mitigation](#-risks--mitigation)
+9. [Dependencies & Assumptions](#-dependencies--assumptions)
+10. [Open Questions](#-open-questions)
+11. [Revision History](#-revision-history)
+
+---
+
+## 📋 Executive Summary
+
+> [2-3 sentence overview of what we're building and why]
+
+**Key Points:**
+- [Point 1: What problem we're solving]
+- [Point 2: Who we're solving it for]
+- [Point 3: What success looks like]
+
+**MVP Target:** [Date or phase]
+
+---
+
+## 🎯 Problem & Opportunity
+
+### Current State
+[Describe the current situation/process from user perspective]
+
+### Problem Statement
+[Clear articulation of the user problem - from BRD]
+
+### Opportunity
+[Why now? What opportunity does this address?]
+
+### Goals
+| Goal | Priority | BRD Reference |
+|------|----------|---------------|
+| [Goal 1] | P0 | BRD §1.2 |
+| [Goal 2] | P1 | BRD §1.2 |
+| [Goal 3] | P2 | BRD §1.2 |
+
+---
+
+## 👥 User Personas & Scenarios
+
+### Personas
+
+| Persona | Role | Description | Key Pain Points | MVP? |
+|---------|------|-------------|-----------------|------|
+| [Name] | [Job Title] | [Who they are, context] | [What frustrates them] | ✓ |
+| [Name] | [Job Title] | [Who they are, context] | [What frustrates them] | ✓ |
+| [Name] | [Job Title] | [Who they are, context] | [What frustrates them] | ✗ v1.1 |
+
+### User Scenarios
+
+**Scenario 1: [Scenario Name]**
+- **Actor:** [Persona]
+- **Trigger:** [What starts this scenario]
+- **Preconditions:** [What must be true before starting]
+- **Steps:**
+  1. [Step 1]
+  2. [Step 2]
+  3. [Step 3]
+- **Outcome:** [Expected result]
+- **Error Paths:** [What could go wrong and how to recover]
+
+**Scenario 2: [Scenario Name]**
+- **Actor:** [Persona]
+- **Trigger:** [What starts this scenario]
+- **Preconditions:** [What must be true before starting]
+- **Steps:**
+  1. [Step 1]
+  2. [Step 2]
+- **Outcome:** [Expected result]
+- **Error Paths:** [What could go wrong and how to recover]
+
+---
+
+## 📖 User Stories
+
+### 🎯 Epic 1: [Epic Name]
+[One-line description of this epic - what user capability does it enable?]
+
+**Story 1.1: [Story Title]**
+```gherkin
+As a [user type],
+I want to [action],
+So that [benefit/value].
+
+Acceptance Criteria:
+✓ GIVEN [context] WHEN [action] THEN [outcome]
+✓ GIVEN [context] WHEN [action] THEN [outcome]
+✓ GIVEN [context] WHEN [action] THEN [outcome]
+```
+**Priority:** P0 | **Effort:** S/M/L | **Dependencies:** None | **BRD Ref:** §3.1
+
+---
+
+**Story 1.2: [Story Title]**
+```gherkin
+As a [user type],
+I want to [action],
+So that [benefit/value].
+
+Acceptance Criteria:
+✓ GIVEN [context] WHEN [action] THEN [outcome]
+✓ GIVEN [context] WHEN [action] THEN [outcome]
+```
+**Priority:** P1 | **Effort:** M | **Dependencies:** Story 1.1 | **BRD Ref:** §3.2
+
+---
+
+### 🎯 Epic 2: [Epic Name]
+[One-line description]
+
+**Story 2.1: [Story Title]**
+...
+
+---
+
+## 🎨 UX & Design Requirements
+
+### User Flow Overview
+```
+[Entry Point] → [Step 1] → [Step 2] → [Decision] → [Outcome]
+                                    ↓
+                              [Alternative Path]
+```
+
+### Interaction Requirements
+| Interaction | Behavior | Priority |
+|------------|----------|----------|
+| [Interaction 1] | [How it should behave from user's perspective] | P0 |
+| [Interaction 2] | [How it should behave from user's perspective] | P1 |
+| [Interaction 3] | [How it should behave from user's perspective] | P2 |
+
+### Response Time Requirements
+| Action | Expected Response | Max Acceptable |
+|--------|-------------------|----------------|
+| [Page load] | < 1 second | < 3 seconds |
+| [Form submission] | < 500ms | < 2 seconds |
+| [Search/query] | < 200ms | < 1 second |
+
+### Accessibility Requirements
+- [ ] Keyboard navigation support
+- [ ] Screen reader compatible
+- [ ] Color contrast WCAG AA
+- [ ] [Other requirements specific to product]
+
+### Error Handling
+| Error Scenario | User Message | Recovery Action |
+|---------------|--------------|-----------------|
+| [Error 1] | [What user sees - friendly message] | [How to recover - user action] |
+| [Error 2] | [What user sees - friendly message] | [How to recover - user action] |
+
+---
+
+## 📊 Success Metrics (HEART)
+
+> Using HEART Framework - optimized for internal tools & platforms
+
+### H - Happiness (满意度)
+| Metric | Current | Target | Measurement |
+|--------|---------|--------|-------------|
+| User Satisfaction Score | - | ≥4.0/5.0 | Quarterly survey |
+| Support Tickets | [Current] | ↓30% | Ticket system |
+| NPS (if applicable) | - | ≥40 | Survey |
+
+### E - Engagement (参与度)
+| Metric | Current | Target | Measurement |
+|--------|---------|--------|-------------|
+| Daily Active Users | - | [Target] | Analytics |
+| Feature Usage Rate | - | ≥70% | Analytics |
+| Session Duration | - | [Target] | Analytics |
+
+### A - Adoption (采用率)
+| Metric | Current | Target | Measurement |
+|--------|---------|--------|-------------|
+| Team Adoption | 0% | 100% by [Date] | Onboarding tracking |
+| New Feature Adoption | - | ≥80% within 30 days | Feature flags |
+| Onboarding Completion | - | ≥90% | Funnel analysis |
+
+### R - Retention (留存率)
+| Metric | Current | Target | Measurement |
+|--------|---------|--------|-------------|
+| Weekly Return Rate | - | ≥85% | Cohort analysis |
+| Churn to Old Process | - | <5% | Process audit |
+| Feature Stickiness | - | ≥60% | DAU/MAU ratio |
+
+### T - Task Success (任务成功率) ⭐ Core for Internal Tools
+| Metric | Current | Target | Measurement |
+|--------|---------|--------|-------------|
+| Task Completion Rate | [Current]% | ≥95% | Funnel analysis |
+| Time to Complete | [Current] min | ↓50% | Time tracking |
+| Error Rate | [Current]% | <2% | Error logging |
+| First-Time Success Rate | - | ≥80% | User testing |
+
+---
+
+## 🔍 Scope
+
+### ✅ In Scope (MVP)
+| Feature | Priority | User Value | BRD Reference |
+|---------|----------|------------|---------------|
+| [Feature 1] | P0 | [Why users need this] | BRD §3.1 |
+| [Feature 2] | P0 | [Why users need this] | BRD §3.2 |
+| [Feature 3] | P1 | [Why users need this] | BRD §3.3 |
+
+### ❌ Out of Scope
+| Item | Reason | Future Consideration |
+|------|--------|---------------------|
+| [Item 1] | [Why not now - business reason, not technical] | [When to reconsider] |
+| [Item 2] | [Why not now - business reason, not technical] | [When to reconsider] |
+
+### 🔮 Future Considerations (Backlog)
+| Feature | Priority | Dependencies |
+|---------|----------|--------------|
+| [Feature X] | P2 | [What needs to happen first] |
+| [Feature Y] | P3 | [What needs to happen first] |
+
+---
+
+## ⚠️ Risks & Mitigation
+
+| Risk | Likelihood | Impact | Mitigation | Owner |
+|------|------------|--------|------------|-------|
+| [Risk 1] | 🔴 High | 🔴 High | [How to address - user/product perspective] | [Name] |
+| [Risk 2] | 🟡 Medium | 🟡 Medium | [How to address - user/product perspective] | [Name] |
+| [Risk 3] | 🟢 Low | 🟡 Medium | [How to address - user/product perspective] | [Name] |
+
+---
+
+## 📎 Dependencies & Assumptions
+
+### Dependencies
+| Dependency | Type | Status | Impact if Blocked |
+|------------|------|--------|-------------------|
+| [Dependency 1] | External/Internal | ⏳ Pending | [User impact] |
+| [Dependency 2] | External/Internal | ✅ Available | [User impact] |
+
+### Assumptions
+- [ ] [Assumption 1 - what we assume about users/behavior]
+- [ ] [Assumption 2 - what we assume about data/content]
+- [ ] [Assumption 3 - what we assume about timeline/resources]
+- [ ] [Assumption 4 - what we assume about training/adoption]
+
+---
+
+## ❓ Open Questions
+
+| # | Question | Owner | Due Date | Status |
+|---|----------|-------|----------|--------|
+| 1 | [Question about user needs/behavior] | [Name] | [Date] | 🔴 Open |
+| 2 | [Question about priority/trade-offs] | [Name] | [Date] | 🟡 In Progress |
+| 3 | [Question about scope] | [Name] | [Date] | 🟢 Resolved |
+
+---
+
+## 📝 Revision History
+
+| Version | Date | Changes | Author | Status |
+|---------|------|---------|--------|--------|
+| v0.1-draft | YYYY-MM-DD | Initial draft | - | 🟡 Draft |
+| v0.2-draft | YYYY-MM-DD | [Changes] | - | 🟡 Draft |
+| v1.0 | YYYY-MM-DD | Approved | - | 🟢 Approved |

--- a/.claude/skills/trd-creator/SKILL.md
+++ b/.claude/skills/trd-creator/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: trd-creator
+description: Use when users ask to "create a TRD", "write technical requirements document", "design architecture", "define API specifications", "create database schema", or need help with technical implementation details AFTER having a PRD. Also triggers when converting product requirements into technical specs, designing system architecture, making technology stack decisions, or when developers need detailed implementation guidance. Make sure to use this skill whenever the user mentions "API design", "database schema", "architecture", "deployment", "technology stack", "system design", or wants to translate product features into concrete technical specifications, even if they don't explicitly ask for a "TRD". Always check if a PRD exists first — if not, recommend creating one.
+---
+
+# TRD Creator
+
+Create comprehensive Technical Requirements Documents (TRDs) that define architecture design, API specifications, database schemas, and technology stack decisions — building on PRD's product specifications to answer HOW to implement.
+
+## Core Principle
+
+**TRD answers "HOW" — not "WHY" or "WHAT".**
+
+- **HOW**: Architecture, APIs, database schemas, deployment, technology choices
+- **NOT**: Business goals, user stories, UX flows, success metrics (those are BRD/PRD)
+
+```
+BRD → PRD → TRD
+WHY/WHO → WHAT (user-facing) → HOW (technical)
+```
+
+**Key insight:** TRD bridges PRD's product features to implementation. If you're writing business goals or user stories → STOP → That belongs in BRD/PRD.
+
+## When to Use This Skill
+
+**Use TRD when:**
+- PRD exists and product features are clear
+- Need to translate features into technical implementation
+- Designing system architecture
+- Defining API specifications
+- Creating database schemas
+- Making technology stack decisions
+
+**Skip TRD when:**
+- No PRD exists (create PRD first using prd-creator skill)
+- Simple feature or bug fix with obvious implementation
+- Technical details already well-defined
+
+## Phase 1: Input Validation (PRD Check)
+
+**CRITICAL: TRD requires PRD as input.**
+
+Before proceeding, ask: "Do you have an existing PRD for this project?"
+
+- **If YES** → Extract key information from PRD
+- **If NO** → Recommend creating PRD first using prd-creator skill
+
+### Extract from PRD
+
+| PRD Section | TRD Input | Purpose |
+|-------------|-----------|---------|
+| User Stories | API endpoints, data models | Each story needs technical implementation |
+| Feature Specs | Components, services | Define what needs to be built |
+| UX Flows | API sequences, state management | Map user actions to system behavior |
+| Success Metrics | Performance requirements | Define SLAs, scaling targets |
+| Scope | Implementation scope | What to build vs defer |
+
+### PRD-TRD Traceability
+
+Every TRD element should trace back to PRD. If you can't trace an API endpoint or data model to a PRD feature → ask: Is this truly needed for MVP?
+
+## Phase 2: Technical Discovery
+
+### Architecture Questions
+
+1. **Deployment Context**: Where will this run? (cloud, on-premise, hybrid)
+2. **Scaling Requirements**: Expected load? Concurrent users? Data volume?
+3. **Integration Points**: External systems? APIs? Services?
+4. **Constraints**: Budget, timeline, compliance, team expertise?
+
+### Technology Questions
+
+1. **Stack Preferences**: Existing standards? Team familiarity?
+2. **Data Requirements**: Relational? Document? Time-series?
+3. **Communication Patterns**: Sync vs async? REST vs GraphQL? Event-driven?
+4. **Observability**: Logging, metrics, tracing requirements?
+
+### Security Questions
+
+1. **Authentication**: How do users authenticate?
+2. **Authorization**: Role-based? Resource-based?
+3. **Data Protection**: Encryption at rest? In transit?
+4. **Compliance**: GDPR? SOC2? Industry-specific?
+
+## Phase 3: Generate TRD
+
+**Read the template from `references/trd-template.md` to generate the TRD document.**
+
+The template includes 11 sections: Executive Summary, System Architecture, API Specifications, Data Models, Technology Stack, Deployment Architecture, Security Design, Performance Requirements, Trade-off Decisions, Open Questions, and Revision History.
+
+**Fill in the template with information gathered from:**
+- PRD (features, user stories, success metrics)
+- Discovery questions (architecture, technology, security)
+- Trade-off analysis for key decisions
+
+## Phase 4: Trade-off Analysis (Critical)
+
+For each significant technical decision, document:
+
+### Format
+
+| Decision | Options | Pros | Cons | Choice | Reason |
+|----------|---------|------|------|--------|--------|
+| [Topic] | [A/B/C] | [Benefits] | [Drawbacks] | [Selected] | [Why this option] |
+
+### Example
+
+| Decision | Options | Pros | Cons | Choice | Reason |
+|----------|---------|------|------|--------|--------|
+| Database | A) PostgreSQL / B) MongoDB | A: ACID, mature / B: Flexible schema | A: Schema migrations / B: No transactions | PostgreSQL | Financial data requires ACID guarantees |
+
+### Key Decisions to Document
+
+- Architecture pattern (monolith vs microservices)
+- Database choice
+- API style (REST vs GraphQL vs gRPC)
+- Authentication method
+- Deployment strategy
+- Caching strategy
+
+## Phase 5: Logic & Completeness Review
+
+After drafting the TRD, perform these checks BEFORE finalizing:
+
+### 5.1 PRD-TRD Traceability
+- Each API endpoint traces to a PRD feature?
+- Each data model supports a PRD requirement?
+- No orphan technical components (no PRD connection)?
+
+### 5.2 Architecture Consistency
+- API layer doesn't bypass service layer
+- Database schema matches data models
+- Deployment matches scaling requirements
+
+### 5.3 No Business Leakage
+**RED FLAG TERMS (should NOT appear in TRD):**
+- User personas, user stories, acceptance criteria
+- Business goals, success metrics (KPI/NPS belong in PRD)
+- UX flows, wireframes, mockups
+
+If found → Replace with technical language (e.g., "User persona" → "Client type with specific access pattern")
+
+### 5.4 Completeness Checklist
+- [ ] Architecture diagram included
+- [ ] All API endpoints documented
+- [ ] Database schema defined
+- [ ] Technology stack listed
+- [ ] Deployment strategy clear
+- [ ] Error handling specified
+- [ ] Security considerations addressed
+
+## Phase 6: Iteration & Refinement
+
+TRD is a living document. Iterate based on:
+- Developer feedback during implementation
+- Technical feasibility findings
+- PRD changes (TRD must stay aligned)
+- New constraints discovered
+
+### Sign-off Process
+Before marking TRD as "approved":
+- [ ] Tech lead has reviewed
+- [ ] All trade-offs documented
+- [ ] All Phase 5 checks pass
+- [ ] Ready for implementation
+
+## Critical Rules
+
+### Rule 1: No Business/Product Content
+
+```
+❌ BAD: "As a user, I want to login quickly"
+✅ GOOD: "POST /auth/login endpoint, <200ms response time"
+
+❌ BAD: "Improve user satisfaction"
+✅ GOOD: "API response time < 100ms p99"
+
+❌ BAD: "Users should feel confident"
+✅ GOOD: "TLS 1.3 encryption for all API traffic"
+```
+
+### Rule 2: Technical Precision
+
+```
+❌ BAD: "Use a database"
+✅ GOOD: "PostgreSQL 15 with read replicas"
+
+❌ BAD: "Make it scalable"
+✅ GOOD: "Horizontal scaling to 10 pods, each 2vCPU/4GB"
+
+❌ BAD: "Handle errors well"
+✅ GOOD: "Return structured error codes: E001-E018"
+```
+
+### Rule 3: Every Decision Needs Trade-offs
+For each major technical choice, document why NOT the alternatives. If you can't explain why you chose X over Y → The decision isn't justified.
+
+## Self-Review Checklist
+
+Before finalizing, verify:
+
+### PRD Alignment
+- [ ] PRD exists: TRD is built on documented product requirements
+- [ ] Traceability: Each API/model traces to PRD feature
+- [ ] Performance: Metrics match PRD success criteria
+
+### Technical Quality
+- [ ] Architecture complete: All layers defined
+- [ ] API specifications: All endpoints documented
+- [ ] Data models: Schema with relationships
+- [ ] Trade-offs: Major decisions justified
+
+### Documentation
+- [ ] No business leakage: Product content moved to PRD
+- [ ] Technical precision: Specific versions, numbers, formats
+- [ ] Diagrams included: Architecture visualized
+
+## Common Anti-Patterns
+
+| Anti-Pattern | Why It's Bad | Fix |
+|--------------|--------------|-----|
+| **Business Leakage** | TRD contains user stories | Replace with API specs |
+| **Vague Tech Stack** | "Use a database" | Specify: "PostgreSQL 15" |
+| **No Trade-offs** | Decisions without alternatives | Add options analysis |
+| **No PRD Reference** | Orphan technical specs | Trace back to PRD |
+| **Missing Error Handling** | Only happy path | Add error codes and recovery |
+| **Over-engineering** | Gold-plating beyond requirements | Cut to MVP scope |
+
+## Relationship to Other Documents
+
+```
+BRD (Business Requirements)
+├── WHY — Business context, goals
+├── WHO — Users, roles
+└── High-level requirements
+
+        ↓ PRD builds on BRD ↓
+
+PRD (Product Requirements)
+├── User Stories — Who needs what and why
+├── Feature Specs — User-facing functionality
+├── UX Flows — How users interact
+└── Success Metrics — Measurable outcomes
+
+        ↓ TRD builds on PRD ↓
+
+TRD (This Document)
+├── System Architecture — Components, layers, communication
+├── API Specifications — Endpoints, requests, responses
+├── Data Models — Database schema, entities
+├── Technology Stack — Frameworks, libraries, versions
+├── Deployment Architecture — Infrastructure, scaling
+└── Security Design — Auth, encryption, compliance
+```
+
+---
+
+## References
+
+- `references/trd-template.md` — Full TRD template with all sections
+- **prd-creator skill** — For creating the prerequisite PRD
+- **brd-creator skill** — For creating the prerequisite BRD

--- a/.claude/skills/trd-creator/references/trd-template.md
+++ b/.claude/skills/trd-creator/references/trd-template.md
@@ -1,0 +1,224 @@
+# TRD Template Reference
+
+> **When to use:** Read this file when you're ready to generate the TRD document after completing discovery.
+
+---
+
+# TRD: [System Name] Technical Requirements Document
+
+> **Version:** v0.1-draft | **Date:** YYYY-MM-DD | **Status:** Draft
+> **PRD Reference:** [Link to PRD document]
+
+---
+
+## 1. Executive Summary
+
+[2-3 sentence overview of the technical approach]
+
+**Key Technical Decisions:**
+- [e.g., Monolithic architecture for MVP simplicity]
+- [e.g., PostgreSQL for ACID compliance]
+- [e.g., Kubernetes deployment for scalability]
+
+---
+
+## 2. System Architecture
+
+### Architecture Overview
+
+[1-2 paragraphs describing the high-level architecture: monolith/microservices, layers, key patterns]
+
+### Component Responsibilities
+
+| Component | Responsibility | Technology | PRD Reference |
+|-----------|---------------|------------|---------------|
+| API Server | Handle HTTP requests, business logic | Go 1.21+ | PRD §X.X |
+| Frontend | User interface | React 18.x | PRD §X.X |
+| Database | Persistent storage | PostgreSQL 15.x | PRD §X.X |
+
+### Communication Patterns
+
+| From | To | Protocol | Purpose |
+|------|-----|----------|---------|
+| Frontend | API Server | HTTPS/REST | User requests |
+| API Server | Database | SQL/TCP | Data persistence |
+| API Server | Cache | Redis Protocol | Session/cache |
+
+---
+
+## 3. API Specifications
+
+### Authentication
+
+| Method | Header | Format |
+|--------|--------|--------|
+| API Key | `X-API-Key` | `key_xxx` |
+| Bearer Token | `Authorization` | `Bearer <jwt>` |
+
+### API Endpoints
+
+| Method | Path | Description | PRD Reference |
+|--------|-----|-------------|---------------|
+| GET | `/api/v1/resources` | List resources (paginated) | PRD §X.X |
+| POST | `/api/v1/resources` | Create resource | PRD §X.X |
+| GET | `/api/v1/resources/{id}` | Get resource by ID | PRD §X.X |
+| PUT | `/api/v1/resources/{id}` | Update resource | PRD §X.X |
+| DELETE | `/api/v1/resources/{id}` | Delete resource | PRD §X.X |
+
+### Response Format
+
+```json
+{
+  "code": 0,
+  "message": "success",
+  "data": { ... },
+  "request_id": "req-xxx"
+}
+```
+
+### Error Codes
+
+| Code | HTTP Status | Description |
+|------|-------------|-------------|
+| 0 | 200 | Success |
+| 1001 | 400 | Invalid request parameters |
+| 1002 | 401 | Unauthorized |
+| 1003 | 403 | Forbidden |
+| 1004 | 404 | Resource not found |
+| 1005 | 409 | Conflict (e.g., duplicate) |
+| 1006 | 500 | Internal server error |
+
+---
+
+## 4. Data Models
+
+### Entity Relationships
+
+[Describe key entities and their relationships: User has many Tasks, Task belongs to Template, etc.]
+
+### Database Schema
+
+```sql
+-- Users Table
+CREATE TABLE users (
+    id VARCHAR(36) PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) UNIQUE NOT NULL,
+    role VARCHAR(50) NOT NULL DEFAULT 'user',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Tasks Table
+CREATE TABLE tasks (
+    id VARCHAR(36) PRIMARY KEY,
+    user_id VARCHAR(36) NOT NULL REFERENCES users(id),
+    title VARCHAR(500) NOT NULL,
+    status VARCHAR(50) NOT NULL DEFAULT 'pending',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_user_id (user_id),
+    INDEX idx_status (status)
+);
+```
+
+---
+
+## 5. Technology Stack
+
+| Layer | Technology | Version | Purpose |
+|-------|------------|---------|---------|
+| Frontend | React | 18.x | UI framework |
+| Backend | Go | 1.21+ | API server |
+| Database | PostgreSQL | 15.x | Primary storage |
+| Cache | Redis | 7.x | Session/cache |
+| Container | Docker | 24.x | Containerization |
+| Orchestration | Kubernetes | 1.28+ | Deployment |
+
+### Key Libraries
+
+| Library | Version | Purpose |
+|---------|---------|---------|
+| gin | 1.9+ | HTTP framework |
+| gorm | 1.25+ | ORM |
+| jwt-go | 5.x | JWT handling |
+
+---
+
+## 6. Deployment Architecture
+
+### Infrastructure
+
+[1-2 sentences: e.g., Deployed on AWS EKS with 3 availability zones, using ALB for load balancing]
+
+### Resource Requirements
+
+| Component | CPU | Memory | Replicas |
+|-----------|-----|--------|----------|
+| API Server | 2 cores | 4GB | 3 |
+| PostgreSQL | 4 cores | 16GB | 2 (HA) |
+| Redis | 2 cores | 8GB | 3 |
+
+### Scaling Strategy
+
+| Metric | Threshold | Action |
+|--------|-----------|--------|
+| CPU | > 70% | Add replica (max 10) |
+| Memory | > 80% | Add replica (max 10) |
+| Requests/sec | > 1000 | Scale horizontally |
+
+---
+
+## 7. Security Design
+
+| Area | Measure | Implementation |
+|------|---------|----------------|
+| Transport | TLS 1.3 | All connections encrypted |
+| Authentication | API Key / JWT | Header-based validation |
+| Authorization | RBAC | Role-based access control |
+| Data | AES-256 encryption | Sensitive fields encrypted at rest |
+| Secrets | Vault / Secrets Manager | No hardcoded credentials |
+
+---
+
+## 8. Performance Requirements
+
+| Operation | Target | Max Acceptable |
+|-----------|--------|----------------|
+| API Response (p95) | < 100ms | < 500ms |
+| Database Query | < 50ms | < 200ms |
+| Cache Hit | < 5ms | < 20ms |
+
+### Throughput
+
+| Metric | Target | Peak Capacity |
+|--------|--------|---------------|
+| Requests/sec | 100 | 500 |
+| Concurrent Users | 1,000 | 5,000 |
+| Data Storage | 100GB | 1TB |
+
+---
+
+## 9. Trade-off Decisions
+
+| Decision | Options | Pros | Cons | Choice | Reason |
+|----------|---------|------|------|--------|--------|
+| Architecture | A) Monolith / B) Microservices | A: Simple deploy / B: Independent scaling | A: Single point of failure / B: Complexity | Monolith | MVP phase, small team |
+| Database | A) PostgreSQL / B) MongoDB | A: ACID, mature / B: Flexible schema | A: Schema migrations / B: No transactions | PostgreSQL | Data requires ACID |
+| API Style | A) REST / B) GraphQL | A: Simple, cacheable / B: Flexible queries | A: Over-fetching / B: Complexity | REST | Standard CRUD operations |
+
+---
+
+## 10. Open Technical Questions
+
+| # | Question | Owner | Priority | Status |
+|---|----------|-------|----------|--------|
+| 1 | [Technical question requiring decision] | [Name] | P0 | Open |
+
+---
+
+## 11. Revision History
+
+| Version | Date | Changes | Author | Status |
+|---------|------|---------|--------|--------|
+| v0.1-draft | YYYY-MM-DD | Initial draft | - | Draft |
+| v1.0 | YYYY-MM-DD | Approved | - | Approved |


### PR DESCRIPTION
## Summary
- Add three documentation skills to help project members create structured requirements documents
- `brd-creator`: Business Requirements Document (WHY/WHO)
- `prd-creator`: Product Requirements Document (WHAT)  
- `trd-creator`: Technical Requirements Document (HOW)

## Skills Included

| Skill | Purpose | Template |
|-------|---------|----------|
| brd-creator | Define business context, goals, users | Inline |
| prd-creator | User stories, features, UX flows | prd-template.md, jtbd-guide.md |
| trd-creator | Architecture, APIs, database schema | trd-template.md |

## Usage
Project members can use these skills by saying:
- "创建 BRD" → triggers brd-creator
- "写 PRD" → triggers prd-creator
- "设计架构" → triggers trd-creator

## Test plan
- [ ] Verify skills are discoverable in Claude Code
- [ ] Test brd-creator triggers correctly
- [ ] Test prd-creator references BRD correctly
- [ ] Test trd-creator references PRD correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)