### PR TITLE
docs: refactor agent.md and add writing guide

### DIFF
--- a/agent.md
+++ b/agent.md
@@ -1,7 +1,7 @@
 # Agent Guide: Agentic Coding Platform
 
-> **Version**: v1.4
-> **Last Updated**: 2026-03-23
+> **Version**: v2.0
+> **Last Updated**: 2026-03-28
 > **Target Audience**: Coding Agents (Claude Code, etc.)
 
 ---
@@ -12,7 +12,6 @@
 
 | Attribute | Value |
 |-----------|-------|
-| **Code Location** | `/Users/yang/workspace/learning/agent-infra/` |
 | **Current Phase** | MVP (v1.0) |
 | **Delivery Target** | 1-2 months |
 
@@ -20,85 +19,139 @@
 
 ---
 
-## 2. Directory Structure
+## 2. Tech Stack
+
+| Layer | Technology |
+|-------|------------|
+| Frontend | React 18 + TypeScript 5 + Ant Design 5 + Vite 5 |
+| Backend | Go 1.21 + Gin 1.9 + GORM 1.25 |
+| Database | OceanBase (MySQL compatible) |
+| Cache/Queue | Redis 6 |
+| Container | Kubernetes (ACK) + Docker |
+| Execution | Claude Code CLI |
+
+---
+
+## 3. Project Structure
 
 ```
-docs/
-├── knowledge/                 # 独立知识库（持续演进）
-│   ├── core-api.md           # 任务/模板管理 API
-│   ├── database.md           # 数据模型与存储
-│   ├── scheduler.md          # 任务调度引擎
-│   ├── executor.md           # 沙箱执行引擎
-│   ├── provider.md           # Agent 运行时配置
-│   ├── capability.md         # 能力注册管理
-│   ├── intervention.md       # 人工干预机制
-│   └── monitoring.md         # 监控告警设计
-│
-├── v{version}/               # 版本目录（按版本隔离）
-│   ├── BRD.md                # 业务需求文档
-│   ├── PRD.md                # 产品需求文档
-│   ├── TRD.md                # 技术设计文档
-│   ├── decisions/            # 架构决策记录（ADR）
-│   │   ├── README.md         # ADR 索引和指南
-│   │   └── adr-template.md   # ADR 模板
-│   ├── issues/               # Issue 摘要
-│   │   └── README.md         # Issue 管理指南
-│   └── plans/                # 执行计划
-│       └── README.md         # 计划管理指南
-│
-├── current -> v{version}/    # 软链接指向当前活跃版本
-│
-└── BRD.md                    # 业务需求文档（根级别）
+agent-infra/
+├── cmd/                     # 程序入口
+├── internal/
+│   ├── api/                 # HTTP 层：handler（参数校验）、middleware（认证/限流）、router、response
+│   ├── service/             # 业务逻辑核心：编排各模块，事务边界在此
+│   ├── repository/          # 数据访问层：封装数据库查询，不包含业务逻辑
+│   ├── model/               # GORM 模型定义，只定义数据结构
+│   ├── scheduler/           # 调度引擎：队列管理、限流、任务分发
+│   ├── executor/            # 执行引擎：Job 生命周期、Pod 管理
+│   ├── config/              # 配置加载与管理
+│   ├── migration/           # 数据库迁移脚本
+│   ├── monitoring/          # 监控指标采集
+│   └── seed/                # 数据库种子数据
+├── pkg/                     # 公共工具：aliyun（SLS 日志）、errors（错误码）等
+├── configs/                 # 配置文件（config.yaml）
+├── scripts/                 # 工具脚本（worktree、cli-runner）
+├── web/                     # 前端：React + Ant Design
+└── deploy/                  # 部署：K8s manifests、Dockerfiles
 ```
 
 ---
 
-## 3. Issue Development Workflow
+## 4. Architecture Constraints
 
-### 3.1 标准工作流程
+**Layer Rules**: Handler → Service → Repository → Model
+
+**Prohibited**:
+- ✗ handler 直接调用 repository
+- ✗ repository 调用 service
+- ✗ scheduler/executor 直接操作数据库
+
+**目录规则**：
+- handler → 只做参数校验和响应格式化，调用 service 处理业务
+- service → 业务逻辑核心，通过 repository 操作数据，事务边界在此
+- repository → 数据访问层，封装数据库查询，不包含业务逻辑
+- model → 只定义数据结构和表映射，不含业务逻辑
+- scheduler/executor → 独立模块，通过 service 层交互，不直接操作数据库
+
+---
+
+## 5. Coding Standards
+
+遵循主流规范（Google Go Style Guide / TypeScript Handbook / Ant Design Docs），以下是本项目规范：
+
+### 通用规范
+
+| Language | Key Points |
+|----------|------------|
+| **Go** | Use `gofmt`/`goimports`; wrap errors with `%w`; interface names: verb+er |
+| **TypeScript** | Functional components + hooks; strict mode; Ant Design components |
+| **Database** | Tables: snake_case plural; Models: PascalCase singular |
+
+**Git Commits**: `<type>(<scope>): <subject>` (feat, fix, docs, style, refactor, test, chore)
+
+### 项目补充规则
+
+| 维度 | 规则 |
+|------|------|
+| 前端 UI | 统一使用 Ant Design 组件，不引入其他 UI 库 |
+| 错误处理 | Go 统一用 `%w` wrap；前端统一用 Ant Design Message 提示 |
+| API 响应 | 遵循 `docs/knowledge/quick-reference.md` 中的 response code 体系 |
+| Context | 所有外部调用传 ctx，不传 nil |
+| 数据库迁移 | 新增字段用 Nullable 或设默认值，不破坏现有数据 |
+
+---
+
+## 6. Documentation Structure
+
+知识库按功能域划分、持续演进、不随版本快照，每个模块记录变更历史。
 
 ```
-┌─────────────────────────────────────────────────────────────────────┐
-│                    Issue Development Workflow                         │
-└─────────────────────────────────────────────────────────────────────┘
-
-Step 1: 创建 Issue Summary
-    │
-    ├── 在 docs/current/issues/ 创建 issue-{number}-{title}.md
-    ├── 使用 issues/README.md 中的模板
-    └── 填写 Summary、Impact、Related 等字段
-    │
-    ▼
-Step 2: 获取背景知识
-    │
-    ├── 读取 docs/current/TRD.md → 了解架构设计
-    ├── 读取 docs/current/decisions/ → 了解相关架构决策
-    ├── 读取 docs/knowledge/{modules}.md → 获取模块知识
-    └── 根据模块选择表确定需要读取的知识
-    │
-    ▼
-Step 3: 生成执行计划
-    │
-    ├── 在 docs/current/plans/ 创建 {YYYY-MM-DD}-{title}.md
-    ├── 使用 plans/README.md 中的模板
-    └── 包含 Context、Objectives、Tasks、Dependencies
-    │
-    ▼
-Step 4: 执行开发
-    │
-    ├── 按照 Plan 中的 Tasks 逐项执行
-    ├── 更新 knowledge 模块的 Change History
-    └── 如有架构决策，创建新的 ADR
-    │
-    ▼
-Step 5: 完成并更新
-    │
-    ├── 更新 Issue 状态为 Resolved
-    ├── 更新 Plan 状态为 Completed
-    └── 记录 Resolution 和关键变更
+docs/
+├── knowledge/               # 独立知识库（按功能域划分，持续演进，详见 §7 模块索引）
+├── v{version}/              # 版本目录（按版本隔离）
+│   ├── BRD.md / PRD.md / TRD.md
+│   ├── decisions/           # ADR（含 README.md 索引和 adr-template.md）
+│   ├── issues/              # Issue 摘要（含 README.md 模板）
+│   └── plans/               # 执行计划（含 README.md 模板）
+├── current -> v{version}/   # 软链接指向当前活跃版本
+└── BRD.md                   # 业务需求文档（根级别）
 ```
 
-### 3.2 模块知识选择
+### 阅读顺序
+
+```
+1. agent.md (本文档) → 了解项目概况与开发流程
+2. docs/current/BRD.md → 了解业务背景
+3. docs/current/PRD.md → 了解产品需求
+4. docs/current/TRD.md → 了解技术设计
+5. docs/current/decisions/ → 了解架构决策
+6. docs/knowledge/{modules}.md → 深入模块细节
+```
+
+---
+
+## 7. Issue Development Workflow
+
+完整流程从拉取代码到清理环境共 14 步：
+
+| Step | 操作 | 要点 |
+|------|------|------|
+| 0 | 拉取最新代码 | `git pull origin main` |
+| 1 | 创建 Worktree | `git worktree add -b feature/issue-{N} .claude/worktrees/issue-{N} main` |
+| 2 | 创建 Issue Summary | `docs/current/issues/issue-{N}-{title}.md`，模板见 `issues/README.md` |
+| 3 | 获取背景知识 | 读 TRD.md → decisions/ → knowledge/{modules}.md，按下方模块选择表确定范围 |
+| 4 | 创建执行计划 | `docs/current/plans/{YYYY-MM-DD}-{title}.md`，模板见 `plans/README.md` |
+| 5 | 开发实现 (TDD) | 按 Plan 逐步实现，编写测试用例，覆盖率 > 80% |
+| 6 | 测试验证 | `make test && make lint && go test -cover ./internal/...` |
+| 7 | 代码审查 | 验证所有测试通过，修复发现的问题 |
+| 8 | 提交推送 | `git commit -m "feat(scope): description" && git push -u origin <branch>` |
+| 9 | 创建 PR | `gh pr create --base main --title "feat: description"` |
+| 10 | 等待合并（人工） | 等待人工审核并合并 PR |
+| 11 | 拉取合并代码 | `git checkout main && git pull origin main` |
+| 12 | 关闭 Issue | `gh issue close {N} --repo {repo}` + 更新 Issue Summary 状态 |
+| 13 | 清理环境 | `git worktree remove .claude/worktrees/issue-{N}` |
+
+### 模块知识选择
 
 | 工作类型 | 加载的知识模块 | 相关 TRD 章节 |
 |---------|---------------|--------------|
@@ -109,89 +162,7 @@ Step 5: 完成并更新
 | 干预功能 | intervention, executor | TRD §3.2 人工干预 |
 | 监控告警 | monitoring | TRD §7 监控告警 |
 
-### 3.3 Issue Summary 模板
-
-创建 `docs/current/issues/issue-{number}-{title}.md`:
-
-```markdown
-# Issue #{number}: {Title}
-
-## Summary
-<!-- Issue 摘要：简述问题或需求 -->
-
-## Impact
-<!-- 影响范围：涉及的模块、用户、系统 -->
-
-## Status
-{Open | In Progress | Resolved | Closed}
-
-## Related
-- PRD: [链接到相关用户故事]
-- TRD: [链接到相关技术设计]
-- ADR: [链接到相关架构决策]
-- Knowledge: [需要加载的知识模块]
-
-## Resolution
-<!-- 解决方案（完成后填写） -->
-
-## Change History
-| 日期 | 变更内容 |
-|------|---------|
-| YYYY-MM-DD | 创建 Issue |
-```
-
-### 3.4 Plan 模板
-
-创建 `docs/current/plans/{YYYY-MM-DD}-{title}.md`:
-
-```markdown
-# Plan: {Title}
-
-## Context
-<!-- 计划背景：Issue 摘要、相关知识背景 -->
-
-## Objectives
-1. {目标1}
-2. {目标2}
-
-## Knowledge Required
-<!-- 需要预读的知识 -->
-- [ ] docs/knowledge/{module1}.md
-- [ ] docs/current/decisions/adr-{number}.md
-
-## Tasks
-
-### Phase 1: {Phase Name}
-- [ ] {Task 1}
-- [ ] {Task 2}
-
-### Phase 2: {Phase Name}
-- [ ] {Task 1}
-
-## Dependencies
-<!-- 依赖项：其他 Issue、外部资源 -->
-
-## Risks
-<!-- 风险项：技术风险、时间风险 -->
-
-## Status
-{Not Started | In Progress | Completed | Blocked}
-```
-
----
-
-## 4. Knowledge Usage Guide
-
-### 4.1 知识库特点
-
-| 特点 | 说明 |
-|------|------|
-| **持续演进** | knowledge/ 不随版本快照，始终更新 |
-| **模块化** | 按功能域划分，按需加载 |
-| **Change History** | 每个模块记录变更历史 |
-| **双向链接** | 与 TRD、ADR 相互引用 |
-
-### 4.2 知识模块索引
+### 知识模块索引
 
 | Module | Purpose | Key Sections |
 |--------|---------|--------------|
@@ -204,123 +175,21 @@ Step 5: 完成并更新
 | `intervention` | 人工干预机制 | Checkpoints, Approvals |
 | `monitoring` | 监控告警设计 | Metrics, Alerts |
 
-### 4.3 阅读顺序
+---
 
-```
-0. readme.md → 项目入口，快速了解项目
-1. agent.md (本文档) → 了解项目概况与开发流程
-2. docs/current/BRD.md → 了解业务背景
-3. docs/current/PRD.md → 了解产品需求
-4. docs/current/TRD.md → 了解技术设计
-5. docs/current/decisions/ → 了解架构决策
-6. docs/knowledge/{modules}.md → 深入模块细节
-```
+## 8. Quick Lookup Tables
+
+详见 `docs/knowledge/quick-reference.md`（API Response Codes、Task Status、Redis Keys）。
 
 ---
 
-## 5. Tech Stack
-
-| Layer | Technology |
-|-------|------------|
-| Frontend | React 18 + TypeScript 5 + Ant Design 5 + Vite 5 |
-| Backend | Go 1.22 + Gin 1.9 + GORM 1.25 |
-| Database | OceanBase (MySQL compatible) |
-| Cache/Queue | Redis 6 |
-| Container | Kubernetes (ACK) + Docker |
-| Execution | Claude Code CLI |
-
----
-
-## 6. Project Structure
-
-```
-agent-infra/
-├── cmd/control-plane/       # Service entry
-├── internal/
-│   ├── api/handler/         # HTTP handlers
-│   ├── api/middleware/      # Auth, rate limit, logging
-│   ├── service/             # Business logic
-│   ├── scheduler/           # Task scheduling
-│   ├── executor/            # Job management
-│   └── model/               # Data models
-├── pkg/                     # Shared utilities
-├── web/                     # Frontend (React)
-└── deploy/k8s/              # K8s manifests
-```
-
----
-
-## 7. Coding Standards
-
-> **Follow external standards. See §11 for all reference links.**
-
-| Language | Key Points |
-|----------|------------|
-| **Go** | Use `gofmt`/`goimports`; wrap errors with `%w`; interface names: verb+er |
-| **TypeScript** | Functional components + hooks; strict mode; Ant Design components |
-| **Database** | Tables: snake_case plural; Models: PascalCase singular |
-
-**Git Commits**: `<type>(<scope>): <subject>` (feat, fix, docs, style, refactor, test, chore)
-
----
-
-## 8. Architecture Constraints
-
-**Layer Rules**: Presentation → Gateway → Application → Data/Execution
-
-**Prohibited**:
-- ✗ Data layer calling Application
-- ✗ Execution accessing database directly
-
-| Module | Responsibility |
-|--------|----------------|
-| Handler | HTTP handling, validation |
-| Service | Business rules, transactions |
-| Scheduler | Queue, rate limiting |
-| Executor | Job lifecycle |
-
----
-
-## 9. Quick Lookup Tables
-
-### API Response
-
-| Code | Meaning |
-|------|---------|
-| 0 | Success |
-| 400xx | Request errors |
-| 401xx | Auth errors |
-| 403xx | Forbidden |
-| 404xx | Not found |
-| 500xx | Server errors |
-
-### Task Status
-
-```
-Pending → Scheduled → Running → Succeeded
-                   ↓          ↓
-               Paused      Failed → Retrying
-```
-
-### Redis Keys
-
-| Pattern | Description |
-|---------|-------------|
-| `scheduler:queue:tasks` | Priority queue (single sorted set with encoded score) |
-| `scheduler:task:{id}:meta` | Task metadata |
-| `scheduler:tenant:{id}:quota` | Tenant quota (concurrency) |
-| `scheduler:tenant:{id}:daily:{date}` | Tenant daily task count (expires at midnight) |
-| `scheduler:global:quota` | Global concurrency quota |
-| `scheduler:task:{id}:state` | Preempted task state (JSON, 24h TTL) |
-| `scheduler:preempted:tasks` | Set of preempted task IDs |
-
----
-
-## 10. Commands
+## 9. Commands
 
 ```bash
 # Backend
 make run test lint
+make test-coverage        # 覆盖率报告
+make db-migrate           # 数据库迁移
 
 # Frontend
 cd web && npm run dev
@@ -328,37 +197,3 @@ cd web && npm run dev
 # Deploy
 make docker-build-all k8s-apply k8s-status
 ```
-
----
-
-## 11. External References
-
-| Category | Resource | URL |
-|----------|----------|-----|
-| **Go** | Google Go Style Guide | https://google.github.io/styleguide/go/ |
-| **Go** | Effective Go | https://go.dev/doc/effective_go |
-| **Go** | Uber Go Style Guide | https://github.com/uber-go/guide/blob/master/style.md |
-| **TypeScript** | TypeScript Handbook | https://www.typescriptlang.org/docs/handbook/ |
-| **React** | React Documentation | https://react.dev/learn |
-| **React** | Airbnb React Style Guide | https://github.com/airbnb/javascript/tree/master/react |
-| **UI** | Ant Design Docs | https://ant.design/docs/react/introduce |
-| **Backend** | Gin Documentation | https://gin-gonic.com/docs/ |
-| **Backend** | GORM Guide | https://gorm.io/docs/ |
-| **Infra** | Kubernetes Documentation | https://kubernetes.io/docs/ |
-| **Infra** | Docker Best Practices | https://docs.docker.com/develop/develop-images/dockerfile_best-practices/ |
-| **Security** | OWASP API Security | https://owasp.org/www-project-api-security/ |
-| **Architecture** | 12-Factor App | https://12factor.net/ |
-| **Agent** | Claude Code CLI Docs | https://docs.anthropic.com/claude/docs/claude-code |
-| **Agent** | MCP Specification | https://modelcontextprotocol.io/ |
-
----
-
-## 12. Changelog
-
-| Version | Changes |
-|---------|---------|
-| v1.4 | 添加 Issue Development Workflow；更新目录结构说明；新增 Issue/Plan 模板 |
-| v1.3 | Added knowledge module index, updated doc paths to v1.0-mvp/ |
-| v1.2 | Removed duplicate references, further simplified |
-| v1.1 | Simplified: reference external standards |
-| v1.0 | Initial version |

--- a/docs/knowledge/agent-md-guide.md
+++ b/docs/knowledge/agent-md-guide.md
@@ -1,0 +1,200 @@
+# agent.md 编写规范
+
+> 本文档指导团队成员编写和维护 `agent.md`，确保 AI 编码代理高效、准确地理解项目规则。
+
+---
+
+## 1. 什么是 agent.md
+
+`agent.md` 是 AI 编码代理（Claude Code、OpenAI Codex、Cursor 等）的操作手册。它告诉代理**怎么干活、遵守什么规则、不该做什么**。
+
+### 与 README.md 的分工
+
+| 文件 | 读者 | 核心定位 |
+|------|------|---------|
+| README.md | 人类开发者 | **项目名片** — 是什么、为什么、怎么跑起来 |
+| agent.md | AI 编码代理 | **操作手册** — 怎么干活、遵守什么规则 |
+
+**每块信息只在一个地方定义完整版，另一处用链接引用。**
+
+---
+
+## 2. 核心原则：规则 > 事实
+
+```
+放什么                              不放什么
+─────────────────────────           ─────────────────────────
+✓ 编码规范 + 项目特有规则            ✗ 外部链接/参考文档
+✓ 架构分层规则 + 禁止事项            ✗ Changelog（git log 是权威）
+✓ Tech Stack（技术选型锚点）         ✗ 详细目录树（子目录展开）
+✓ Project Structure（第一层）        ✗ Issue/Plan 完整模板
+✓ 开发工作流                        ✗ 快速参考表（Redis keys 等）
+✓ 知识模块索引                      ✗ 安装步骤/环境搭建
+✓ 常用命令                          ✗ Self-evident 的常识
+```
+
+判断标准：**agent 能否从代码中推断？** 能推断的不放，推断不了的放。
+
+---
+
+## 3. 放什么：逐项说明
+
+### 必须放
+
+| 内容 | 理由 | 来源 |
+|------|------|------|
+| **Tech Stack** | agent 生成代码需要匹配选型（Go 版本、框架、UI 库），从 go.mod 推断不够快且可能推断错 | Anthropic + OpenAI |
+| **Project Structure** | agent 没有直觉，需要明确知道代码在哪、职责是什么。比人类更需要这份导航图 | OpenAI + Google |
+| **Architecture Constraints** | 防止 agent 破坏分层边界，这是它无法从代码推断的约束 | Anthropic + Cursor |
+| **Coding Standards** | 项目特有的编码规则（不是通用规范的重复） | 所有公司一致推荐 |
+| **Development Workflow** | agent 的操作步骤（Issue → Plan → 开发 → 测试 → PR） | OpenAI |
+| **Commands** | 构建、测试、部署命令 — agent 无法猜测的项目特定命令 | Anthropic + OpenAI |
+
+### 不放
+
+| 内容 | 理由 | 替代方案 |
+|------|------|---------|
+| 外部链接 | agent 不读外部链接，主流规范已内化在训练数据中 | 在编码规范中只写项目特有规则 |
+| Changelog | git log 是权威来源，手动维护容易过时 | 不需要 |
+| 详细目录树 | 会随代码膨胀，违反稳定性原则 | 只列第一层，深层用 `ls` 发现 |
+| 完整模板 | 占空间且已在别处定义 | 引用 issues/README.md 等文件 |
+| 参考数据 | 静态数据占空间但不是每次都用 | 外置到 knowledge/quick-reference.md |
+| 安装步骤 | 人类操作用，agent 不需要 | 放 README.md |
+
+---
+
+## 4. Token Cache 稳定性原则
+
+agent.md 在每次对话中全量加载到上下文窗口，因此：
+
+### 为什么重要
+
+- **每次对话都消耗 token** — 文件越大，每轮对话成本越高
+- **注意力稀释** — Anthropic 官方警告：过长的指令导致 agent 忽略重要规则
+- **Cache 失效** — 文件频繁变化会导致 prompt cache 失效，增加延迟和成本
+
+### 稳定性策略
+
+1. **不放会频繁变化的内容** — 目录只列第一层，新增文件在已有目录下不需要更新
+2. **不放可推断的事实** — 让 agent 自己去 `find`、`grep`、`cat`
+3. **只放稳定的规则和导航** — 架构约束、编码规范、模块索引
+
+### 目标行数
+
+| 来源 | 推荐行数 |
+|------|---------|
+| Anthropic 官方 | < 500 行 |
+| 社区最佳实践 | 150-200 行 |
+| **本项目建议** | **150-200 行** |
+
+> 判断方法：对每一行问"去掉这行，agent 会不会犯错？"如果不会，就删掉。
+> — Anthropic 官方建议
+
+---
+
+## 5. 目录结构的写法
+
+### 规则：只到第一层
+
+```
+✗ 过于详细（会膨胀）
+├── internal/
+│   ├── api/
+│   │   ├── handler/         # HTTP handlers
+│   │   ├── middleware/      # Auth, rate limit
+│   │   ├── response/        # Response format
+│   │   └── router/          # Routes
+│   ├── service/             # Business logic
+│   └── ...
+
+✓ 恰到好处（第一层 + 职责注释）
+├── internal/
+│   ├── api/                 # HTTP 层：handler、middleware、router、response
+│   ├── service/             # 业务逻辑核心，事务边界
+│   ├── repository/          # 数据访问层
+│   └── model/               # GORM 模型定义
+```
+
+**为什么**：新增文件在已有目录下不需要更新 agent.md，只有新增顶层目录才需要。
+
+---
+
+## 6. 消除重复
+
+同一信息在 agent.md 内部或与 README.md 之间不要出现两次。
+
+| 常见重复 | 解决方式 |
+|---------|---------|
+| 目录规则 vs Architecture Constraints | 合并到 Architecture Constraints |
+| docs 目录树 vs 知识模块索引 | 保留索引表，简化树 |
+| README 的 Workflow vs agent.md 的 Workflow | agent.md 放完整版，README 只放链接 |
+| 通用规范 vs 外部链接 | 只写项目特有规则，不说"参考某链接" |
+
+---
+
+## 7. 压缩手段
+
+| 手段 | 效果 | 示例 |
+|------|------|------|
+| 表格替代 ASCII 流程图 | 信息密度更高 | 14 步工作流：ASCII → 表格 |
+| 引用替代内联 | 避免重复 | 模板引用 issues/README.md |
+| 一句话替代多行描述 | 去掉抽象描述 | 知识库特点 4 行 → 1 句话 |
+| 外置参考数据 | 主文件不膨胀 | Quick Lookup → knowledge/ |
+| 合并重复内容 | 消除冗余 | 目录规则 + Architecture 表合并 |
+
+---
+
+## 8. 推荐章节顺序
+
+**先理解项目，再教怎么干活：**
+
+```
+1. Project Overview          # 建立上下文
+2. Tech Stack                # 选型锚点
+3. Project Structure         # 导航图（第一层 + 职责注释）
+4. Architecture Constraints  # 分层规则 + 目录规则 + 禁止事项
+5. Coding Standards          # 通用规范 + 项目补充规则
+6. Documentation Structure   # 文档导航 + 阅读顺序
+7. Issue Development Workflow # 操作步骤 + 模块知识选择 + 模块索引
+8. Quick Lookup Tables       # 外置引用
+9. Commands                  # 常用命令
+```
+
+---
+
+## 9. 维护检查清单
+
+每次修改 agent.md 时，逐项检查：
+
+- [ ] **新增内容是规则还是事实？** 事实通常不该加
+- [ ] **agent 能否从代码推断？** 能推断的不需要加
+- [ ] **是否与 README.md 重复？** 只在一个地方保留完整版
+- [ ] **是否与 agent.md 其他章节重复？** 合并而非新增
+- [ ] **行数是否超过 200？** 超过则需要考虑压缩或外置
+- [ ] **修改后是否需要同步更新其他文件？** 检查引用关系
+
+### 定期审计（建议每季度）
+
+1. 对比 agent.md 中的信息与代码实际状态
+2. 删除 agent 已经能正确遵循的规则（不再需要的指令）
+3. 添加 agent 反复犯错后总结的新规则
+4. 验证技术栈版本与 go.mod / package.json 一致
+5. 验证目录结构与实际代码一致
+
+---
+
+## 10. 参考资料
+
+| 来源 | 链接 | 要点 |
+|------|------|------|
+| Anthropic 官方 | code.claude.com/docs/en/best-practices | 文件层级、大小建议、避免过度指定 |
+| OpenAI Codex | developers.openai.com/codex/guides/agents-md | AGENTS.md 规范、32KB 限制 |
+| Cursor | cursor.com/blog/agent-best-practices | 引用文件而非复制内容、按需添加规则 |
+| Google Cloud | cloud.google.com/blog 上的 AI coding best practices | GEMINI.md 概念、跨会话连续性 |
+| AGENTS.md 标准 | 社区跨工具标准，20,000+ 仓库采用 | symlink 策略实现跨工具兼容 |
+
+> 关键共识（Anthropic + OpenAI + Cursor）：
+> - 短小精悍比面面俱到更有效
+> - 只在 agent 犯错后添加规则，不要预防性堆砌
+> - 引用文件，不要复制内容
+> - 定期清理，删除已经能正确遵循的指令

--- a/docs/knowledge/core-api.md
+++ b/docs/knowledge/core-api.md
@@ -1,22 +1,29 @@
 # Core API Knowledge
 
-> **Last Updated**: 2026-03-23
+> **Last Updated**: 2026-03-26
 > **PRD Version**: v0.7-draft
 > **TRD Version**: v2.4
 
 ## 1. Overview
 
-Core API 模块负责任务管理、模板管理、用户认证等核心 HTTP API 的设计与实现。
+Core API 模块负责租户管理、任务管理、模板管理、Provider管理、Capability管理等核心 HTTP API 的设计与实现。
 
 **模块职责**：
+- 租户 CRUD 操作与配额管理
 - 任务 CRUD 操作与状态管理
 - 模板 CRUD 操作与版本管理
+- Provider CRUD 操作与连接测试
+- Capability CRUD 操作与激活管理
+- 健康检查与就绪检查
 - API Key 认证与权限校验
 - 请求参数校验与响应序列化
 
 **核心概念**：
+- **Tenant**: 租户，平台的多租户隔离单元，包含资源配额
 - **Task**: 一次 Agent 执行的抽象单元，是平台的核心业务对象
 - **Template**: 可复用的任务配置，定义任务类型和执行策略
+- **Provider**: AI 能力提供者，定义底层 AI 服务的连接和配置
+- **Capability**: 平台能力，包括工具、技能和 Agent 运行时
 - **API Key**: 用户认证凭证，用于 API 调用身份验证
 
 ## 2. Product Requirements (from PRD)
@@ -30,21 +37,39 @@ Core API 模块负责任务管理、模板管理、用户认证等核心 HTTP AP
 | US-D02 | 任务执行监控 | 实时显示进度阶段、流式输出日志、显示资源消耗 |
 | US-D03 | 人工干预任务 | 支持暂停/恢复/取消、注入指令、修改参数、记录干预历史 |
 | US-A02 | 任务模板管理 | 创建/编辑/发布/废弃模板、YAML格式定义、版本化管理 |
+| US-A03 | 租户管理 | 创建/编辑/删除租户、配额管理、状态管理 |
+| US-A04 | Provider管理 | 注册/配置/测试Provider、设置默认Provider |
+| US-A05 | Capability管理 | 注册/激活/停用Capability、权限级别管理 |
 
 ### 2.2 业务规则
 
-1. **任务创建**：
-   - 必须选择有效的模板
+1. **租户管理**：
+   - 租户名称必须唯一
+   - 配额值必须为正数
+   - 暂停的租户无法创建新任务
+
+2. **任务创建**：
+   - 必须选择有效的模板（可选）
    - 参数必须通过模板定义的校验规则
    - 必须通过配额检查（租户级）
 
-2. **任务状态转换**：
+3. **任务状态转换**：
    - 只能从当前状态转换到合法的目标状态
    - 终态任务（succeeded/failed/cancelled）不可再变更
 
-3. **模板发布**：
+4. **模板发布**：
    - 只有 draft 状态的模板可以发布
    - 发布后的模板不可删除，只能废弃
+
+5. **Provider管理**：
+   - Provider 有三种作用域：system、tenant、user
+   - tenant 作用域必须关联 tenant_id
+   - user 作用域必须关联 user_id
+
+6. **Capability管理**：
+   - Capability 有三种类型：tool、skill、agent_runtime
+   - 租户级 Capability 必须关联 tenant_id
+   - 全局 Capability 的 tenant_id 为 NULL
 
 ## 3. Technical Design (from TRD)
 
@@ -55,9 +80,12 @@ control-plane/
 ├── internal/
 │   ├── api/
 │   │   ├── handler/
+│   │   │   ├── tenant.go      # 租户 HTTP 处理器
 │   │   │   ├── task.go        # 任务 HTTP 处理器
 │   │   │   ├── template.go    # 模板 HTTP 处理器
-│   │   │   ├── tenant.go      # 租户 HTTP 处理器
+│   │   │   ├── provider.go    # Provider HTTP 处理器
+│   │   │   ├── capability.go  # Capability HTTP 处理器
+│   │   │   ├── health.go      # 健康检查处理器
 │   │   │   └── user.go        # 用户 HTTP 处理器
 │   │   ├── middleware/
 │   │   │   ├── auth.go        # API Key 认证
@@ -65,50 +93,726 @@ control-plane/
 │   │   │   └── logger.go      # 日志
 │   │   └── router.go          # 路由注册
 │   └── service/
-│       ├── task_service.go    # 任务业务逻辑
-│       └── template_service.go # 模板业务逻辑
+│       ├── tenant_service.go    # 租户业务逻辑
+│       ├── task_service.go      # 任务业务逻辑
+│       ├── template_service.go  # 模板业务逻辑
+│       ├── provider_service.go  # Provider 业务逻辑
+│       └── capability_service.go # Capability 业务逻辑
 ```
 
-### 3.2 API 规范
+### 3.2 通用规范
 
-#### 任务管理 `/api/v1/tasks`
+#### 3.2.1 Base URL
 
-| 方法 | 路径 | 说明 | 角色 |
-|------|------|------|------|
-| POST | /tasks | 创建任务 | developer |
-| GET | /tasks | 任务列表 | developer |
-| GET | /tasks/:id | 任务详情 | developer |
-| POST | /tasks/:id/pause | 暂停任务 | developer, operator |
-| POST | /tasks/:id/resume | 恢复任务 | developer, operator |
-| POST | /tasks/:id/cancel | 取消任务 | developer, operator |
-| POST | /tasks/:id/inject | 注入指令 | developer, operator |
-| POST | /tasks/:id/retry | 重试任务 | developer, operator |
-| GET | /tasks/:id/logs | 获取日志 | developer, operator |
-| GET | /tasks/:id/queue-position | 查询排队位置 | developer |
-| GET | /tasks/:id/metrics | 获取执行指标 | developer |
+所有 API 均在 `/api/v1/` 路径下。
 
-#### 模板管理 `/api/v1/templates`
-
-| 方法 | 路径 | 说明 | 角色 |
-|------|------|------|------|
-| GET | /templates | 模板列表 | developer |
-| GET | /templates/:id | 模板详情 | developer |
-| POST | /templates | 创建模板 | admin |
-| PUT | /templates/:id | 更新模板 | admin |
-| DELETE | /templates/:id | 删除模板 | admin |
-| POST | /templates/:id/publish | 发布模板 | admin |
-| POST | /templates/:id/deprecate | 废弃模板 | admin |
-| GET | /templates/:id/versions | 版本历史 | admin |
-| POST | /templates/:id/validate | 校验模板 | admin |
-
-### 3.3 Service 接口定义
+#### 3.2.2 通用响应格式
 
 ```go
+type Response struct {
+    Code    int         `json:"code"`
+    Message string      `json:"message"`
+    Data    interface{} `json:"data,omitempty"`
+}
+
+type PaginatedData struct {
+    Items    interface{} `json:"items"`
+    Total    int64       `json:"total"`
+    Page     int         `json:"page"`
+    PageSize int         `json:"page_size"`
+}
+```
+
+#### 3.2.3 错误码定义
+
+| Code | HTTP Status | 说明 |
+|------|-------------|------|
+| 0 | 200 | 成功 |
+| 400 | 400 | 请求参数错误 |
+| 401 | 401 | 未授权 |
+| 404 | 404 | 资源不存在 |
+| 500 | 500 | 内部服务器错误 |
+
+### 3.3 认证机制
+
+**API Key 认证流程**：
+1. 请求头携带 `Authorization: Bearer <api_key>`
+2. Auth 中间件提取并验证 API Key
+3. 计算密钥 SHA256 哈希值，查询数据库匹配
+4. 验证通过后注入用户上下文到请求
+
+**API Key 存储规范**：
+- 只存储 SHA256 哈希值，不存储明文
+- 存储前 8 位前缀用于识别
+- 支持过期时间和撤销操作
+
+### 3.4 API 规范
+
+#### 3.4.1 租户管理 `/api/v1/tenants`
+
+| 方法 | 路径 | 说明 | 角色 |
+|------|------|------|------|
+| POST | /tenants | 创建租户 | admin |
+| GET | /tenants | 租户列表 | admin |
+| GET | /tenants/:id | 租户详情 | admin |
+| PUT | /tenants/:id | 更新租户 | admin |
+| DELETE | /tenants/:id | 删除租户 | admin |
+
+**租户模型**：
+
+```go
+type Tenant struct {
+    BaseModel                              // ID, CreatedAt, UpdatedAt
+    Name             string `json:"name"`  // Required, 唯一
+    QuotaCPU         int    `json:"quota_cpu"`         // Default: 4
+    QuotaMemory      int64  `json:"quota_memory"`      // GB, Default: 16
+    QuotaConcurrency int    `json:"quota_concurrency"` // Default: 10
+    QuotaDailyTasks  int    `json:"quota_daily_tasks"` // Default: 100
+    Status           string `json:"status"`            // active, suspended
+}
+```
+
+**创建租户请求**：
+
+```http
+POST /api/v1/tenants
+Content-Type: application/json
+
+{
+    "name": "acme-corp",
+    "quota_cpu": 8,
+    "quota_memory": 32,
+    "quota_concurrency": 20,
+    "quota_daily_tasks": 500
+}
+```
+
+**成功响应**：
+
+```json
+{
+    "code": 0,
+    "message": "success",
+    "data": {
+        "id": "550e8400-e29b-41d4-a716-446655440000",
+        "name": "acme-corp",
+        "quota_cpu": 8,
+        "quota_memory": 32,
+        "quota_concurrency": 20,
+        "quota_daily_tasks": 500,
+        "status": "active",
+        "created_at": "2026-03-26T10:00:00Z",
+        "updated_at": "2026-03-26T10:00:00Z"
+    }
+}
+```
+
+**查询参数**：
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| page | int | 页码，默认 1 |
+| page_size | int | 每页数量，默认 10，最大 100 |
+| status | string | 状态过滤：active, suspended |
+| search | string | 名称搜索 |
+
+**列表响应**：
+
+```json
+{
+    "code": 0,
+    "message": "success",
+    "data": {
+        "items": [...],
+        "total": 100,
+        "page": 1,
+        "page_size": 20
+    }
+}
+```
+
+**更新租户请求**：
+
+```http
+PUT /api/v1/tenants/:id
+Content-Type: application/json
+
+{
+    "name": "acme-corp-updated",
+    "quota_cpu": 16,
+    "status": "active"
+}
+```
+
+**业务规则**：
+- name 必填且唯一
+- quota 值必须为正数
+- status 必须为 active 或 suspended
+
+#### 3.4.2 任务管理 `/api/v1/tasks`
+
+> **实现状态说明**：
+> - ✅ 基础 CRUD 已实现
+> - 🔄 控制类端点（pause/resume/cancel 等）计划在后续版本实现
+
+| 方法 | 路径 | 说明 | 角色 | 状态 |
+|------|------|------|------|------|
+| POST | /tasks | 创建任务 | developer | ✅ |
+| GET | /tasks | 任务列表 | developer | ✅ |
+| GET | /tasks/:id | 任务详情 | developer | ✅ |
+| PUT | /tasks/:id | 更新任务 | developer | ✅ |
+| DELETE | /tasks/:id | 删除任务 | developer | ✅ |
+| POST | /tasks/:id/pause | 暂停任务 | developer, operator | 🔄 |
+| POST | /tasks/:id/resume | 恢复任务 | developer, operator | 🔄 |
+| POST | /tasks/:id/cancel | 取消任务 | developer, operator | 🔄 |
+| POST | /tasks/:id/inject | 注入指令 | developer, operator | 🔄 |
+| POST | /tasks/:id/retry | 重试任务 | developer, operator | 🔄 |
+| GET | /tasks/:id/logs | 获取日志 | developer, operator | 🔄 |
+| GET | /tasks/:id/queue-position | 查询排队位置 | developer | 🔄 |
+| GET | /tasks/:id/metrics | 获取执行指标 | developer | 🔄 |
+
+**任务模型**：
+
+```go
+type Task struct {
+    BaseModel
+    TenantID     string         `json:"tenant_id"`
+    TemplateID   *string        `json:"template_id,omitempty"`
+    CreatorID    string         `json:"creator_id"`
+    ProviderID   string         `json:"provider_id"`
+    Name         string         `json:"name"`
+    Status       string         `json:"status"`       // pending, scheduled, running, paused, waiting_approval, retrying, succeeded, failed, cancelled
+    Priority     string         `json:"priority"`     // high, normal, low
+    Params       datatypes.JSON `json:"params,omitempty"`
+    Description  string         `json:"description,omitempty"`
+    ErrorMessage string         `json:"error_message,omitempty"`
+    Result       datatypes.JSON `json:"result,omitempty"`
+}
+```
+
+**创建任务请求**：
+
+```http
+POST /api/v1/tasks
+Content-Type: application/json
+
+{
+    "tenant_id": "550e8400-e29b-41d4-a716-446655440000",
+    "template_id": "660e8400-e29b-41d4-a716-446655440001",
+    "creator_id": "770e8400-e29b-41d4-a716-446655440002",
+    "provider_id": "880e8400-e29b-41d4-a716-446655440003",
+    "name": "Fix authentication bug",
+    "priority": "high",
+    "description": "修复登录页面的认证问题",
+    "params": {
+        "repo": "example/repo",
+        "issue": 123
+    }
+}
+```
+
+**成功响应**：
+
+```json
+{
+    "code": 0,
+    "message": "success",
+    "data": {
+        "id": "990e8400-e29b-41d4-a716-446655440004",
+        "tenant_id": "550e8400-e29b-41d4-a716-446655440000",
+        "template_id": "660e8400-e29b-41d4-a716-446655440001",
+        "creator_id": "770e8400-e29b-41d4-a716-446655440002",
+        "provider_id": "880e8400-e29b-41d4-a716-446655440003",
+        "name": "Fix authentication bug",
+        "status": "pending",
+        "priority": "high",
+        "description": "修复登录页面的认证问题",
+        "params": {
+            "repo": "example/repo",
+            "issue": 123
+        },
+        "created_at": "2026-03-26T10:00:00Z",
+        "updated_at": "2026-03-26T10:00:00Z"
+    }
+}
+```
+
+**查询参数**：
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| page | int | 页码，默认 1 |
+| page_size | int | 每页数量，默认 10，最大 100 |
+| status | string | 状态过滤 |
+| priority | string | 优先级过滤 |
+| tenant_id | string | 租户ID过滤 |
+| search | string | 名称搜索 |
+
+**状态转换规则**：
+
+| 当前状态 | 可转换目标状态 |
+|----------|----------------|
+| pending | scheduled, cancelled |
+| scheduled | running, cancelled |
+| running | paused, succeeded, failed, cancelled |
+| paused | running, cancelled |
+| waiting_approval | running, cancelled |
+| retrying | running, failed, cancelled |
+| succeeded | - (终态) |
+| failed | - (终态) |
+| cancelled | - (终态) |
+
+**业务规则**：
+- tenant_id、creator_id、provider_id、name 必填
+- template_id 可选
+- priority: high, normal, low（默认 normal）
+- 终态任务不可变更
+
+#### 3.4.3 模板管理 `/api/v1/templates`
+
+> **实现状态说明**：
+> - ✅ 基础 CRUD 已实现
+> - 🔄 生命周期管理端点（publish/deprecate 等）计划在后续版本实现
+
+| 方法 | 路径 | 说明 | 角色 | 状态 |
+|------|------|------|------|------|
+| GET | /templates | 模板列表 | developer | ✅ |
+| GET | /templates/:id | 模板详情 | developer | ✅ |
+| POST | /templates | 创建模板 | admin | ✅ |
+| PUT | /templates/:id | 更新模板 | admin | ✅ |
+| DELETE | /templates/:id | 删除模板 | admin | ✅ |
+| POST | /templates/:id/publish | 发布模板 | admin | 🔄 |
+| POST | /templates/:id/deprecate | 废弃模板 | admin | 🔄 |
+| GET | /templates/:id/versions | 版本历史 | admin | 🔄 |
+| POST | /templates/:id/validate | 校验模板 | admin | 🔄 |
+
+**模板模型**：
+
+```go
+type Template struct {
+    BaseModel
+    TenantID   string  `json:"tenant_id"`
+    Name       string  `json:"name"`
+    Version    string  `json:"version"`      // Default: 1.0.0
+    Spec       string  `json:"spec"`         // YAML format
+    SceneType  string  `json:"scene_type"`   // coding, ops, analysis, content, custom
+    Status     string  `json:"status"`       // draft, published, deprecated
+    ProviderID *string `json:"provider_id,omitempty"`
+}
+```
+
+**创建模板请求**：
+
+```http
+POST /api/v1/templates
+Content-Type: application/json
+
+{
+    "tenant_id": "550e8400-e29b-41d4-a716-446655440000",
+    "name": "Code Review Template",
+    "version": "1.0.0",
+    "spec": "apiVersion: agent/v1\nkind: Template\nmetadata:\n  name: code-review\nspec:\n  steps:\n    - name: analyze\n      action: analyze_code",
+    "scene_type": "coding",
+    "provider_id": "880e8400-e29b-41d4-a716-446655440003"
+}
+```
+
+**成功响应**：
+
+```json
+{
+    "code": 0,
+    "message": "success",
+    "data": {
+        "id": "a90e8400-e29b-41d4-a716-446655440005",
+        "tenant_id": "550e8400-e29b-41d4-a716-446655440000",
+        "name": "Code Review Template",
+        "version": "1.0.0",
+        "spec": "apiVersion: agent/v1\nkind: Template\n...",
+        "scene_type": "coding",
+        "status": "draft",
+        "provider_id": "880e8400-e29b-41d4-a716-446655440003",
+        "created_at": "2026-03-26T10:00:00Z",
+        "updated_at": "2026-03-26T10:00:00Z"
+    }
+}
+```
+
+**查询参数**：
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| page | int | 页码，默认 1 |
+| page_size | int | 每页数量，默认 10，最大 100 |
+| status | string | 状态过滤：draft, published, deprecated |
+| scene_type | string | 场景类型过滤 |
+| tenant_id | string | 租户ID过滤 |
+
+**业务规则**：
+- name、tenant_id 必填
+- scene_type: coding, ops, analysis, content, custom
+- status: draft, published, deprecated
+- spec 必须为有效的 YAML 格式
+- 只有 draft 状态的模板可以删除
+
+#### 3.4.4 Provider 管理 `/api/v1/providers`
+
+| 方法 | 路径 | 说明 | 角色 |
+|------|------|------|------|
+| POST | /providers | 创建 Provider | admin |
+| GET | /providers | Provider 列表 | developer, admin |
+| GET | /providers/available | 可用 Provider 列表 | developer, admin |
+| GET | /providers/:id | Provider 详情 | developer, admin |
+| PUT | /providers/:id | 更新 Provider | admin |
+| DELETE | /providers/:id | 删除 Provider | admin |
+| POST | /providers/:id/test | 测试连接 | admin |
+| PUT | /providers/:id/set-default | 设置默认 | admin |
+
+**Provider 模型**：
+
+```go
+type Provider struct {
+    ID             string         `json:"id"`
+    Scope          ProviderScope  `json:"scope"`          // system, tenant, user
+    TenantID       *string        `json:"tenant_id"`
+    UserID         *string        `json:"user_id"`
+    Name           string         `json:"name"`
+    Type           ProviderType   `json:"type"`           // claude_code, anthropic_compatible, openai_compatible, custom
+    Description    string         `json:"description"`
+    APIEndpoint    string         `json:"api_endpoint"`
+    APIKeyRef      string         `json:"api_key_ref"`
+    ModelMapping   datatypes.JSON `json:"model_mapping"`
+    RuntimeType    RuntimeType    `json:"runtime_type"`   // cli, api, sdk
+    RuntimeImage   string         `json:"runtime_image"`
+    RuntimeCommand datatypes.JSON `json:"runtime_command"`
+    EnvVars        datatypes.JSON `json:"env_vars"`
+    Permissions    datatypes.JSON `json:"permissions"`
+    EnabledPlugins datatypes.JSON `json:"enabled_plugins"`
+    ExtraParams    datatypes.JSON `json:"extra_params"`
+    Status         ProviderStatus `json:"status"`         // active, inactive, deprecated
+    CreatedAt      time.Time      `json:"created_at"`
+    UpdatedAt      time.Time      `json:"updated_at"`
+}
+```
+
+**创建 Provider 请求**：
+
+```http
+POST /api/v1/providers
+Content-Type: application/json
+
+{
+    "name": "Claude Code Provider",
+    "type": "claude_code",
+    "scope": "tenant",
+    "tenant_id": "550e8400-e29b-41d4-a716-446655440000",
+    "description": "Primary Claude Code instance for Acme Corp",
+    "api_endpoint": "https://api.anthropic.com",
+    "api_key_ref": "k8s-secret://claude-api-key",
+    "model_mapping": {
+        "default": "claude-3-opus",
+        "sonnet": "claude-3-sonnet",
+        "haiku": "claude-3-haiku"
+    },
+    "runtime_type": "cli",
+    "runtime_image": "claude-code:latest",
+    "runtime_command": {
+        "entrypoint": "/usr/local/bin/claude",
+        "args": ["--model", "${MODEL}"]
+    },
+    "env_vars": {
+        "ANTHROPIC_API_KEY": "${API_KEY_REF}"
+    },
+    "permissions": {
+        "allow_network": true,
+        "allow_filesystem": true
+    },
+    "enabled_plugins": ["git", "docker"]
+}
+```
+
+**成功响应**：
+
+```json
+{
+    "code": 0,
+    "message": "success",
+    "data": {
+        "id": "ba0e8400-e29b-41d4-a716-446655440006",
+        "scope": "tenant",
+        "tenant_id": "550e8400-e29b-41d4-a716-446655440000",
+        "name": "Claude Code Provider",
+        "type": "claude_code",
+        "description": "Primary Claude Code instance for Acme Corp",
+        "api_endpoint": "https://api.anthropic.com",
+        "status": "active",
+        "created_at": "2026-03-26T10:00:00Z",
+        "updated_at": "2026-03-26T10:00:00Z"
+    }
+}
+```
+
+**测试连接请求**：
+
+```http
+POST /api/v1/providers/:id/test
+Content-Type: application/json
+```
+
+**测试连接响应**：
+
+```json
+{
+    "code": 0,
+    "message": "success",
+    "data": {
+        "success": true,
+        "message": "Connection successful",
+        "response_time_ms": 150,
+        "details": {
+            "api_reachable": true,
+            "auth_valid": true,
+            "models_available": ["claude-3-opus", "claude-3-sonnet", "claude-3-haiku"]
+        }
+    }
+}
+```
+
+**设置默认 Provider**：
+
+```http
+PUT /api/v1/providers/:id/set-default
+Content-Type: application/json
+```
+
+**查询参数**：
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| page | int | 页码，默认 1 |
+| page_size | int | 每页数量，默认 10，最大 100 |
+| scope | string | 作用域过滤：system, tenant, user |
+| type | string | 类型过滤 |
+| status | string | 状态过滤：active, inactive, deprecated |
+
+**业务规则**：
+- name 必填
+- scope: system, tenant, user
+- tenant 作用域必须提供 tenant_id
+- user 作用域必须提供 user_id
+- type: claude_code, anthropic_compatible, openai_compatible, custom
+- status: active, inactive, deprecated
+
+#### 3.4.5 Capability 管理 `/api/v1/capabilities`
+
+| 方法 | 路径 | 说明 | 角色 |
+|------|------|------|------|
+| POST | /capabilities | 创建 Capability | admin |
+| GET | /capabilities | Capability 列表 | developer, admin |
+| GET | /capabilities/:id | Capability 详情 | developer, admin |
+| PUT | /capabilities/:id | 更新 Capability | admin |
+| DELETE | /capabilities/:id | 删除 Capability | admin |
+| POST | /capabilities/:id/activate | 激活 Capability | admin |
+| POST | /capabilities/:id/deactivate | 停用 Capability | admin |
+
+**Capability 模型**：
+
+```go
+type Capability struct {
+    ID              string           `json:"id"`
+    TenantID        *string          `json:"tenant_id"`       // NULL = global
+    Type            CapabilityType   `json:"type"`            // tool, skill, agent_runtime
+    Name            string           `json:"name"`
+    Description     string           `json:"description"`
+    Version         string           `json:"version"`         // Default: 1.0.0
+    Config          datatypes.JSON   `json:"config"`
+    Schema          datatypes.JSON   `json:"schema"`
+    PermissionLevel PermissionLevel  `json:"permission_level"` // public, restricted, admin_only
+    Status          CapabilityStatus `json:"status"`           // active, inactive
+    CreatedAt       time.Time        `json:"created_at"`
+    UpdatedAt       time.Time        `json:"updated_at"`
+}
+```
+
+**创建 Capability 请求**：
+
+```http
+POST /api/v1/capabilities
+Content-Type: application/json
+
+{
+    "type": "tool",
+    "name": "Code Linter",
+    "description": "Lint code files using ESLint and Prettier",
+    "version": "1.0.0",
+    "tenant_id": "550e8400-e29b-41d4-a716-446655440000",
+    "permission_level": "public",
+    "config": {
+        "command": "eslint",
+        "args": ["--fix", "--config", ".eslintrc.json"],
+        "timeout_ms": 30000
+    },
+    "schema": {
+        "type": "object",
+        "properties": {
+            "files": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "Files to lint"
+            },
+            "fix": {
+                "type": "boolean",
+                "default": true,
+                "description": "Auto-fix issues"
+            }
+        },
+        "required": ["files"]
+    }
+}
+```
+
+**成功响应**：
+
+```json
+{
+    "code": 0,
+    "message": "success",
+    "data": {
+        "id": "cb0e8400-e29b-41d4-a716-446655440007",
+        "tenant_id": "550e8400-e29b-41d4-a716-446655440000",
+        "type": "tool",
+        "name": "Code Linter",
+        "description": "Lint code files using ESLint and Prettier",
+        "version": "1.0.0",
+        "permission_level": "public",
+        "status": "active",
+        "config": {
+            "command": "eslint",
+            "args": ["--fix", "--config", ".eslintrc.json"],
+            "timeout_ms": 30000
+        },
+        "created_at": "2026-03-26T10:00:00Z",
+        "updated_at": "2026-03-26T10:00:00Z"
+    }
+}
+```
+
+**激活 Capability**：
+
+```http
+POST /api/v1/capabilities/:id/activate
+Content-Type: application/json
+```
+
+**激活响应**：
+
+```json
+{
+    "code": 0,
+    "message": "Capability activated successfully",
+    "data": {
+        "id": "cb0e8400-e29b-41d4-a716-446655440007",
+        "status": "active"
+    }
+}
+```
+
+**停用 Capability**：
+
+```http
+POST /api/v1/capabilities/:id/deactivate
+Content-Type: application/json
+```
+
+**查询参数**：
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| page | int | 页码，默认 1 |
+| page_size | int | 每页数量，默认 10，最大 100 |
+| type | string | 类型过滤：tool, skill, agent_runtime |
+| status | string | 状态过滤：active, inactive |
+| tenant_id | string | 租户ID过滤 |
+
+**业务规则**：
+- name 必填
+- type: tool, skill, agent_runtime
+- permission_level: public, restricted, admin_only
+- tenant_id 为 NULL 表示全局 Capability
+- 新创建的 Capability 默认为 active 状态，可通过 /deactivate 端点停用
+
+#### 3.4.6 健康检查 (无需认证)
+
+| 方法 | 路径 | 说明 |
+|------|------|------|
+| GET | /health | 健康检查 |
+| GET | /ready | 就绪检查 |
+
+**健康检查请求**：
+
+```http
+GET /health
+```
+
+**健康检查响应**：
+
+```json
+{
+    "status": "healthy",
+    "service": "control-plane",
+    "version": "0.1.0"
+}
+```
+
+**就绪检查请求**：
+
+```http
+GET /ready
+```
+
+**就绪检查响应**：
+
+```json
+{
+    "ready": true,
+    "checks": {
+        "database": "healthy",
+        "redis": "healthy"
+    }
+}
+```
+
+**不健康响应示例**：
+
+```json
+{
+    "ready": false,
+    "checks": {
+        "database": "healthy",
+        "redis": "unhealthy: connection refused"
+    }
+}
+```
+
+### 3.5 Service 接口定义
+
+```go
+// TenantService 接口
+type TenantService interface {
+    CreateTenant(ctx context.Context, req *CreateTenantRequest) (*Tenant, error)
+    GetTenant(ctx context.Context, tenantID string) (*Tenant, error)
+    ListTenants(ctx context.Context, filter *TenantFilter) ([]*Tenant, int64, error)
+    UpdateTenant(ctx context.Context, tenantID string, req *UpdateTenantRequest) error
+    DeleteTenant(ctx context.Context, tenantID string) error
+}
+
 // TaskService 接口
 type TaskService interface {
     CreateTask(ctx context.Context, req *CreateTaskRequest) (*Task, error)
     GetTask(ctx context.Context, taskID string) (*Task, error)
     ListTasks(ctx context.Context, filter *TaskFilter) ([]*Task, int64, error)
+    UpdateTask(ctx context.Context, taskID string, req *UpdateTaskRequest) error
+    DeleteTask(ctx context.Context, taskID string) error
     UpdateTaskStatus(ctx context.Context, taskID string, status TaskStatus, reason string) error
     PauseTask(ctx context.Context, taskID string) error
     ResumeTask(ctx context.Context, taskID string) error
@@ -131,20 +835,30 @@ type TemplateService interface {
     ValidateTemplate(ctx context.Context, spec *TemplateSpec) error
     RenderTemplate(ctx context.Context, templateID string, params map[string]interface{}) (*ResolvedSpec, error)
 }
+
+// ProviderService 接口
+type ProviderService interface {
+    CreateProvider(ctx context.Context, req *CreateProviderRequest) (*Provider, error)
+    GetProvider(ctx context.Context, providerID string) (*Provider, error)
+    ListProviders(ctx context.Context, filter *ProviderFilter) ([]*Provider, int64, error)
+    GetAvailableProviders(ctx context.Context, userID string) ([]*Provider, error)
+    UpdateProvider(ctx context.Context, providerID string, req *UpdateProviderRequest) error
+    DeleteProvider(ctx context.Context, providerID string) error
+    TestProviderConnection(ctx context.Context, providerID string) (*ConnectionTestResult, error)
+    SetDefaultProvider(ctx context.Context, userID string, providerID string) error
+}
+
+// CapabilityService 接口
+type CapabilityService interface {
+    CreateCapability(ctx context.Context, req *CreateCapabilityRequest) (*Capability, error)
+    GetCapability(ctx context.Context, capabilityID string) (*Capability, error)
+    ListCapabilities(ctx context.Context, filter *CapabilityFilter) ([]*Capability, int64, error)
+    UpdateCapability(ctx context.Context, capabilityID string, req *UpdateCapabilityRequest) error
+    DeleteCapability(ctx context.Context, capabilityID string) error
+    ActivateCapability(ctx context.Context, capabilityID string) error
+    DeactivateCapability(ctx context.Context, capabilityID string) error
+}
 ```
-
-### 3.4 认证机制
-
-**API Key 认证流程**：
-1. 请求头携带 `Authorization: Bearer <api_key>`
-2. Auth 中间件提取并验证 API Key
-3. 计算密钥 SHA256 哈希值，查询数据库匹配
-4. 验证通过后注入用户上下文到请求
-
-**API Key 存储规范**：
-- 只存储 SHA256 哈希值，不存储明文
-- 存储前 8 位前缀用于识别
-- 支持过期时间和撤销操作
 
 ## 4. Implementation Notes
 
@@ -154,12 +868,15 @@ type TemplateService interface {
 2. **错误处理**：统一错误码和错误消息格式
 3. **日志记录**：请求入口/出口记录结构化日志
 4. **响应格式**：统一 JSON 响应格式，包含 code/message/data
+5. **软删除**：所有删除操作为软删除，保留 deleted_at 字段
+6. **分页查询**：统一使用 page 和 page_size 参数
 
 ### 4.2 已知约束
 
 1. MVP 阶段仅支持 API Key 认证，后续对接企业 IAM
 2. 任务列表查询性能依赖数据库索引优化
 3. 流式日志需要配合 WebSocket 实现
+4. Provider 连接测试依赖外部服务可用性
 
 ### 4.3 技术决策
 
@@ -168,9 +885,12 @@ type TemplateService interface {
 | Web框架 | Gin | 轻量级、性能优异 |
 | 参数校验 | validator v10 | Gin 内置支持、声明式规则 |
 | 认证方式 | API Key | MVP 阶段简单可用 |
+| 数据库 | PostgreSQL + GORM | 成熟稳定、功能完善 |
+| 缓存 | Redis | 高性能、支持分布式 |
 
 ## 5. Change History
 
 | Date | Version | Issue | PRD Ref | TRD Ref | Changes |
 |------|---------|-------|---------|---------|---------|
 | 2026-03-23 | v1.0 | - | §3.2, §4.1, §4.2 | §4.1, §7.1, §7.2 | 初始定义：任务/模板管理 API |
+| 2026-03-26 | v2.0 | #8, #9, #10, #11, #12 | §3.2, §4.1, §4.2 | §4.1, §7.1, §7.2 | 新增：租户/Provider/Capability/健康检查 API；完善所有 API 的请求/响应示例和业务规则 |

--- a/docs/knowledge/quick-reference.md
+++ b/docs/knowledge/quick-reference.md
@@ -1,0 +1,40 @@
+# Quick Reference
+
+> 本文档包含开发中高频查询的参考数据。
+
+---
+
+## API Response Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 400xx | Request errors |
+| 401xx | Auth errors |
+| 403xx | Forbidden |
+| 404xx | Not found |
+| 500xx | Server errors |
+
+---
+
+## Task Status
+
+```
+Pending → Scheduled → Running → Succeeded
+                   ↓          ↓
+               Paused      Failed → Retrying
+```
+
+---
+
+## Redis Keys
+
+| Pattern | Description |
+|---------|-------------|
+| `scheduler:queue:tasks` | Priority queue (single sorted set with encoded score) |
+| `scheduler:task:{id}:meta` | Task metadata |
+| `scheduler:tenant:{id}:quota` | Tenant quota (concurrency) |
+| `scheduler:tenant:{id}:daily:{date}` | Tenant daily task count (expires at midnight) |
+| `scheduler:global:quota` | Global concurrency quota |
+| `scheduler:task:{id}:state` | Preempted task state (JSON, 24h TTL) |
+| `scheduler:preempted:tasks` | Set of preempted task IDs |


### PR DESCRIPTION
## Summary
- 重构 agent.md：章节重排（先理解项目再教干活）、压缩行数（365→199）、修复过时信息（Go 版本、repository 层缺失）、删除冗余内容（外部链接、Changelog、内联模板）
- 新增 `docs/knowledge/quick-reference.md`：从 agent.md 外置的快速参考表（API Codes、Task Status、Redis Keys）
- 新增 `docs/knowledge/agent-md-guide.md`：agent.md 编写规范，综合 Anthropic/OpenAI/Google/Cursor 最佳实践

## Key Changes

### agent.md
- §2 Tech Stack: Go 1.22 → 1.21（与 go.mod 一致）
- §3 Project Structure: 展开子目录 → 只列第一层（token cache 稳定性）
- §4 Architecture: handler→service→model → handler→service→**repository**→model
- §5 Coding Standards: 保留原有规范 + 新增项目补充规则
- §7 Workflow: 5步文档流程 → 14步完整开发流程
- §9 Commands: 补充 test-coverage、db-migrate
- 删除: External References、Changelog、内联模板、内联 Quick Lookup Tables

### New Files
- `docs/knowledge/quick-reference.md` — API Response Codes、Task Status、Redis Keys
- `docs/knowledge/agent-md-guide.md` — 编写规范（10章节，含维护检查清单）

## Test plan
- [ ] 验证 agent.md 内容与代码实际状态一致
- [ ] 验证 quick-reference.md 内容完整迁移
- [ ] 阅读 agent-md-guide.md 确认可操作性

🤖 Generated with [Claude Code](https://claude.com/claude-code)