### PR TITLE
chore: add CLAUDE.md, update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,5 +84,5 @@ configs/local.yml
 # Air live reload
 .air/
 
-# Claude Code
-.claude/
+# Claude Code personal preferences (project-level are shared)
+CLAUDE.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,13 @@
+# Claude Code Instructions
+
+@agent.md
+
+## Preferences
+
+- 用中文回复，代码和注释用英文
+- commit 时自动加 Co-Authored-By: Claude <noreply@anthropic.com>
+
+## Permissions
+
+- 允许执行 make test, make lint, go test 命令
+- 允许执行 gh pr create, gh issue 操作


### PR DESCRIPTION
## Summary

- 新增 `CLAUDE.md`：通过 `@agent.md` 导入项目指南，附加 Claude Code 偏好和权限
- 更新 `.gitignore`：`.claude/` 和 `CLAUDE.md` 不再忽略（项目共享），仅忽略 `CLAUDE.local.md`（个人偏好）

## 文件分层

| 文件 | 提交 | 用途 |
|------|------|------|
| `.claude/` | 是 | 项目共享 skills/hooks |
| `CLAUDE.md` | 是 | 项目级 AI 指令 |
| `CLAUDE.local.md` | 否 | 个人项目偏好 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)